### PR TITLE
BLD: Build process raises if libraries are missing.

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 Cython
 Pillow
 nose
+pkgconfig


### PR DESCRIPTION
This supercedes #34. To summarize it and revisit the discussion there:

The most important change in stated in the title. Currently, if a required library is not found, the build finishes "sucessfully" and failure is only discovered when the user tries `import av`. Now, a `LibraryNotFoundError` stops the build and lists the missing libraries.

The build script also fails immediately and informatively if someone attempts to run it on Windows.

The code that ran `pkg-config` through a Unix pipe has been replaced by a module on PyPI, [pkgconfig](https://pypi.python.org/pypi/pkgconfig/1.0.0), that provides this functionality. Removing that low-level code from PyAV's setup.py file makes it cleaner and more approachable. If we eventually support Windows, as I still hope to do, this refactor paves the way for a parallel implementation of `pkg_exists` and `get_pkg_info` using `ctypes.WinDLL` instead of `pkgconfig`.

A disadvantage of this change is that setup.py requires `pkgconfig`, and setuptools' `setup_requires` is not clever enough to install what it needs and then continue the build. We could make the build process smoother by distrbuting pkgconfig (it's only [one file](https://github.com/danielballan/PyAV/blob/use-pkgconfig/setup.py)) with PyAV in, say, `PyAV/extern/pkgconfig/`. What do you think?

Finally, unlike #34, this does *not* cythonize sources -- `make build` is still required. I still think it would be good for `python setup.py develop` to run the whole build, cythonizing included, but that's not part of this PR.

And, again unlike #34, this does *not* change the way the build directory's contents are automatically detected. You convinced me. :- )