### PR TITLE
Update _core.pyx

### DIFF
--- a/av/_core.pyx
+++ b/av/_core.pyx
@@ -4,6 +4,7 @@ cimport libav as lib
 lib.av_register_all()
 lib.avformat_network_init()
 lib.avdevice_register_all()
+lib.avcodec_register_all()
 
 # Exports.
 time_base = lib.AV_TIME_BASE


### PR DESCRIPTION
I m running PyAV in a bundle using pyinstaller. 

Without this modification codecs are not found when running PyAV inside an application bundle.

I m not sure why this is not required when running PyAv as a script (the 'normal' way). 

