### PR TITLE
fix for building on windows using mingw64-32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,15 @@ default: build
 cythonize:
 	python setup.py cythonize
 
+wheel: build-mingw32
+	python setup.py bdist_wheel
+
+build-mingw32:
+	# before running, set PKG_CONFIG_PATH to the pkgconfig dir of the ffmpeg build.
+	# set PKG_CONFIG_PATH=D:\dev\3rd\media-autobuild_suite\local32\bin-video\ffmpegSHARED\lib\pkgconfig
+	CFLAGS=$(CFLAGS) LDFLAGS=$(LDFLAGS) python setup.py build_ext --inplace -c mingw32
+	mv *.pyd av
+
 build:
 	CFLAGS=$(CFLAGS) LDFLAGS=$(LDFLAGS) python setup.py build_ext --inplace --debug
 

--- a/av/__init__.py
+++ b/av/__init__.py
@@ -1,3 +1,8 @@
+# Add the native FFMPEG and MinGW libraries to executable path, so that the
+# AV pyd files can find them.
+import os
+if os.name == 'nt':
+    os.environ['PATH'] = os.path.abspath(os.path.dirname(__file__)) + os.pathsep + os.environ['PATH']
 
 # MUST import the core before anything else in order to initalize the underlying
 # library that is being wrapped.

--- a/scripts/generate_video.py
+++ b/scripts/generate_video.py
@@ -28,10 +28,16 @@ def which(program):
 ffmpeg_cmd = None
 avconv_cmd = None
 
-if which('ffmpeg'):
-    ffmpeg_cmd = [which('ffmpeg'), '-y', '-f', 'lavfi', '-i']
-if which('avconv'):
-    avconv_cmd = [which('avconv'),'-y', '-filter_complex']
+if os.name == 'nt':
+   ffmpeg_bin, avconv_bin = 'ffmpeg.exe', 'avconv.exe'
+else:
+   ffmpeg_bin, avconv_bin = 'ffmpeg', 'avconv'
+
+
+if which(ffmpeg_bin):
+    ffmpeg_cmd = [which(ffmpeg_bin), '-y', '-f', 'lavfi', '-i']
+if which(avconv_bin):
+    avconv_cmd = [which(avconv_bin),'-y', '-filter_complex']
     
 if not ffmpeg_cmd and not avconv_cmd:
     print('Unable to find ffmpeg or avconve command')


### PR DESCRIPTION
Patch that makes it possible to compile the project on windows using the [mingw64 compiler](http://mingw-w64.yaxm.org/doku.php).
I've only tested with the 32-bit version of the compiler since I'm only using the official 32-bit version of python 2.7 on that platform.

I imaging this patch will have to be reworked a lot before you feel it could be considered, since it *smells* a bit forced atm. However I've tried to group the windows specific parts into one conditional per file, to make it easy to spot what parts are "generic" and which are very platform specific.

The patch requires the user to put the compiled libav libraries and their two mingw dll dependencies into the av-directory, so that your cython wrappers can find them at runtime. If the user forgets to do that, a "helpful" assertion error will be triggered on the windows platform.

Final remark is that since there's no standard directory for libraries on windows, people who build ffmpeg on that platform may place the code and build artifacts anywhere. Since you rely on pkg-config to figure out how which source files to analyze and which libraries to link against, windows users will have to give setuputils a hint. That is, set `PKG_CONFIG_PATH` to point to the `pkgconfig` directory that resulted from their build of ffmpeg.

The unix/linux behavior should be unchanged.

Let me know what you think.