### PR TITLE
Fix: AudioStream._codec_context.coded_frame can be None, causing SEGV

### DIFF
--- a/av/audio/stream.pyx
+++ b/av/audio/stream.pyx
@@ -148,8 +148,9 @@ cdef class AudioStream(Stream):
                 self._stream.time_base
             )
             
-        if self._codec_context.coded_frame.key_frame:
-            packet.struct.flags |= lib.AV_PKT_FLAG_KEY
+        if self._codec_context.coded_frame:
+            if self._codec_context.coded_frame.key_frame:
+                packet.struct.flags |= lib.AV_PKT_FLAG_KEY
 
         packet.struct.stream_index = self._stream.index
         packet.stream = self

--- a/av/container.pyx
+++ b/av/container.pyx
@@ -445,6 +445,9 @@ cdef class OutputContainer(Container):
             codec_context.time_base.num = rate.denominator
             codec_context.time_base.den = rate.numerator
 
+            stream.time_base.num = rate.denominator
+            stream.time_base.den = rate.numerator
+
         # Some Sane audio defaults
         elif codec.type == lib.AVMEDIA_TYPE_AUDIO:
             codec_context.sample_fmt = codec.sample_fmts[0]
@@ -453,6 +456,10 @@ cdef class OutputContainer(Container):
             codec_context.sample_rate = rate or 48000
             codec_context.channels = 2
             codec_context.channel_layout = lib.AV_CH_LAYOUT_STEREO
+
+            rate = Fraction(rate)
+            stream.time_base.num = rate.denominator
+            stream.time_base.den = rate.numerator
 
         # Some formats want stream headers to be separate
         if self.proxy.ptr.oformat.flags & lib.AVFMT_GLOBALHEADER:


### PR DESCRIPTION
Hi, I ran into this issue when trying to encode files with audio track. Took the same approach as you did in VideoStream.encode.

I'm wondering if coded_frame will ever be set in case of audio frames. Seems like coded_frame is referenced by video/image codecs only..

http://ffmpeg.org/doxygen/trunk/structAVCodecContext.html#afdebc347b4f74e0b9271ff37cabc96e8