### PR TITLE
Fix bug when file size can't represent by int

### DIFF
--- a/av/container.pyx
+++ b/av/container.pyx
@@ -63,7 +63,7 @@ cdef int64_t pyio_seek(void *opaque, int64_t offset, int whence) nogil:
     with gil:
         return pyio_seek_gil(opaque, offset, whence)
 
-cdef int pyio_seek_gil(void *opaque, int64_t offset, int whence):
+cdef int64_t pyio_seek_gil(void *opaque, int64_t offset, int whence):
     cdef ContainerProxy self
     try:
         self = <ContainerProxy>opaque

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ def update_extend(dst, src):
 # This is expanded heavily by the `config` command.
 extension_extra = {
     'include_dirs': ['include'], # These are PyAV's includes.
+    'library_dirs': [],
 }
 
 # The macros which describe what functions and structure members we have


### PR DESCRIPTION
PyAV will throw `OverflowError: value too large to convert to int` when opening a python file object larger than 2GB, but open by filename is ok.
I found that `pyio_seek_gil` should return int64_t instead of int for opening a large file.