### PR TITLE
Add Encoder and Decoder classes

### DIFF
--- a/av/__init__.py
+++ b/av/__init__.py
@@ -21,3 +21,5 @@ from av.container import open
 from av.utils import AVError
 from av.video.format import VideoFormat
 from av.video.frame import VideoFrame
+from av.encode import Encoder
+from av.decode import Decoder

--- a/av/audio/fifo.pyx
+++ b/av/audio/fifo.pyx
@@ -114,7 +114,13 @@ cdef class AudioFifo:
             self.pts_offset -= nb_samples
         
         return frame
-    
+
+    def iter(self, unsigned int nb_samples=0, bint partial=False):
+        frame = self.read(nb_samples, partial)
+        while frame:
+            yield frame
+            frame = self.read(nb_samples, partial)
+
     property samples:
         """Number of audio samples (per channel) """
         def __get__(self):

--- a/av/audio/fifo.pyx
+++ b/av/audio/fifo.pyx
@@ -85,6 +85,9 @@ cdef class AudioFifo:
         if not partial and self.samples < nb_samples:
             return
 
+        if partial:
+            nb_samples = min(self.samples, nb_samples)
+
         cdef int ret
         cdef int linesize
         cdef int sample_size

--- a/av/audio/stream.pxd
+++ b/av/audio/stream.pxd
@@ -12,14 +12,6 @@ cdef class AudioStream(Stream):
 
     cdef readonly AudioLayout layout
     cdef readonly AudioFormat format
-    
-    # Hold onto the frames that we will decode until we have a full one.
-    cdef AudioFrame next_frame
 
     # For encoding.
     cdef AudioResampler resampler
-    cdef AudioFifo fifo
-
-    cpdef encode(self, AudioFrame)
-
-

--- a/av/audio/stream.pyx
+++ b/av/audio/stream.pyx
@@ -43,25 +43,8 @@ cdef class AudioStream(Stream):
     property channels:
         def __get__(self):
             return self._codec_context.channels
-        
-    cdef _decode_one(self, lib.AVPacket *packet, int *data_consumed):
 
-        if not self.next_frame:
-            self.next_frame = alloc_audio_frame()
-
-        cdef int completed_frame = 0
-        data_consumed[0] = err_check(lib.avcodec_decode_audio4(self._codec_context, self.next_frame.ptr, &completed_frame, packet))
-        if not completed_frame:
-            return
-        
-        cdef AudioFrame frame = self.next_frame
-        self.next_frame = None
-        
-        frame._init_properties()
-        
-        return frame
-    
-    cpdef encode(self, AudioFrame input_frame):
+    def encode(self, AudioFrame input_frame=None):
         """Encodes a frame of audio, returns a packet if one is ready.
         The output packet does not necessarily contain data for the most recent frame, 
         as encoders can delay, split, and combine input frames internally as needed.
@@ -74,83 +57,59 @@ cdef class AudioStream(Stream):
             self.resampler = AudioResampler(
                 self.format,
                 self.layout,
-                self._codec_context.sample_rate
-            )
-        if not self.fifo:
-            self.fifo = AudioFifo()
+                self._codec_context.sample_rate)
 
-        # if input_frame:
-        #     print 'input_frame.ptr.pts', input_frame.ptr.pts
+        cdef AudioFrame resampled_frame
+        if input_frame:
+            resampled_frame = self.resampler.resample(input_frame)
+        else:
+            resampled_frame = input_frame
 
-        # Resample, and re-chunk. A None frame will flush the resampler,
-        # and then flush the fifo.
-        cdef AudioFrame resampled_frame = self.resampler.resample(input_frame)
         if resampled_frame:
-            self.fifo.write(resampled_frame)
-            # print 'resampled_frame.ptr.pts', resampled_frame.ptr.pts
 
-        # Pull partial frames if we were requested to flush (via a None frame).
-        cdef AudioFrame fifo_frame = self.fifo.read(self._codec_context.frame_size, partial=input_frame is None)
-
-        cdef Packet packet = Packet()
-        cdef int got_packet = 0
-
-        if fifo_frame:
-
-            # If the fifo_frame has a valid pts, scale it to the codec's time_base.
+            # If the resampled_frame has a valid pts, scale it to the codec's time_base.
             # Remember that the AudioFifo time_base is always 1/sample_rate!
-            if fifo_frame.ptr.pts != lib.AV_NOPTS_VALUE:
-                fifo_frame.ptr.pts = lib.av_rescale_q(
-                    fifo_frame.ptr.pts, 
-                    fifo_frame._time_base,
-                    self._codec_context.time_base
-                )
+            if resampled_frame.ptr.pts != lib.AV_NOPTS_VALUE:
+                resampled_frame.ptr.pts = lib.av_rescale_q(
+                    resampled_frame.ptr.pts,
+                    resampled_frame._time_base,
+                    self._codec_context.time_base)
             else:
-                fifo_frame.ptr.pts = lib.av_rescale(
+                resampled_frame.ptr.pts = lib.av_rescale(
                     self._codec_context.frame_number,
                     self._codec_context.sample_rate,
-                    self._codec_context.frame_size,
+                    self._codec_context.frame_size)
+
+        cdef Packet packet
+        for packet in self.coder.encode(resampled_frame):
+            # Rescale some times which are in the codec's time_base to the
+            # stream's time_base.
+            if packet.struct.pts != lib.AV_NOPTS_VALUE:
+                packet.struct.pts = lib.av_rescale_q(
+                    packet.struct.pts,
+                    self._codec_context.time_base,
+                    self._stream.time_base
                 )
-                
-        err_check(lib.avcodec_encode_audio2(
-            self._codec_context,
-            &packet.struct,
-            fifo_frame.ptr if fifo_frame is not None else NULL,
-            &got_packet,
-        ))
-        if not got_packet:
-            return
-        
-        # Rescale some times which are in the codec's time_base to the
-        # stream's time_base.
-        if packet.struct.pts != lib.AV_NOPTS_VALUE:
-            packet.struct.pts = lib.av_rescale_q(
-                packet.struct.pts,
-                self._codec_context.time_base,
-                self._stream.time_base
-            )
-        if packet.struct.dts != lib.AV_NOPTS_VALUE:
-            packet.struct.dts = lib.av_rescale_q(
-                packet.struct.dts,
-                self._codec_context.time_base,
-                self._stream.time_base
-            )
-        if packet.struct.duration > 0:
-            packet.struct.duration = lib.av_rescale_q(
-                packet.struct.duration,
-                self._codec_context.time_base,
-                self._stream.time_base
-            )
-           
-        # `coded_frame` is "the picture in the bitstream"; does this make
-        # sense for audio?  
-        if self._codec_context.coded_frame:
-            if self._codec_context.coded_frame.key_frame:
-                packet.struct.flags |= lib.AV_PKT_FLAG_KEY
+            if packet.struct.dts != lib.AV_NOPTS_VALUE:
+                packet.struct.dts = lib.av_rescale_q(
+                    packet.struct.dts,
+                    self._codec_context.time_base,
+                    self._stream.time_base
+                )
+            if packet.struct.duration > 0:
+                packet.struct.duration = lib.av_rescale_q(
+                    packet.struct.duration,
+                    self._codec_context.time_base,
+                    self._stream.time_base
+                )
 
-        packet.struct.stream_index = self._stream.index
-        packet.stream = self
-        
-        return packet
-        
+            # `coded_frame` is "the picture in the bitstream"; does this make
+            # sense for audio?
+            if self._codec_context.coded_frame:
+                if self._codec_context.coded_frame.key_frame:
+                    packet.struct.flags |= lib.AV_PKT_FLAG_KEY
 
+            packet.struct.stream_index = self._stream.index
+            packet.stream = self
+
+            yield packet

--- a/av/codec.pxd
+++ b/av/codec.pxd
@@ -12,6 +12,6 @@ cdef class Codec(object):
 
 
 cdef class CodecContext(object):
-
+    cdef public dict options
+    cdef object _container
     cdef lib.AVCodecContext *ptr
-    cdef readonly Codec

--- a/av/container/input.pyx
+++ b/av/container/input.pyx
@@ -27,7 +27,7 @@ cdef class InputContainer(Container):
                 # Our understanding is that there is little overlap bettween
                 # options for containers and streams, so we use the same dict.
                 # FIXME: This expects per-stream options.
-                &options.ptr
+                &options.ptr if options.ptr else NULL
             )
         self.proxy.err_check(ret)
 

--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -124,17 +124,7 @@ cdef class OutputContainer(Container):
         cdef Stream stream
         cdef _Dictionary options
         for stream in self.streams:
-            if not lib.avcodec_is_open(stream._codec_context):
-                options = self.options.copy()
-                self.proxy.err_check(lib.avcodec_open2(
-                    stream._codec_context,
-                    stream._codec,
-                    # Our understanding is that there is little overlap bettween
-                    # options for containers and streams, so we use the same dict.
-                    # Possible TODO: expose per-stream options.
-                    &options.ptr
-                ))
-            dict_to_avdict(&stream._stream.metadata, stream.metadata, clear=True)
+            stream.coder.open()
 
         # Open the output file, if needed.
         # TODO: is the avformat_write_header in the right place here?

--- a/av/decode.pxd
+++ b/av/decode.pxd
@@ -1,0 +1,13 @@
+cimport libav as lib
+
+from codec cimport CodecContext
+
+from av.packet cimport Packet
+from av.frame cimport Frame
+
+cdef class Decoder(CodecContext):
+    cdef Frame next_frame
+    cdef decode_one(self, Packet packet, int *data_consumed)
+    cdef decode_video_frame(self, Packet packet, int *data_consumed)
+    cdef decode_audio_frame(self, Packet packet, int *data_consumed)
+    cdef decode_subtitle_frame(self, Packet packet, int *data_consumed)

--- a/av/decode.pyx
+++ b/av/decode.pyx
@@ -1,0 +1,150 @@
+from libc.stdint cimport uint8_t
+from av.utils cimport err_check
+from av.packet cimport Packet
+from av.frame cimport Frame
+from av.audio.frame cimport alloc_audio_frame, AudioFrame
+from av.video.frame cimport alloc_video_frame, VideoFrame
+from av.subtitles.subtitle cimport SubtitleProxy, SubtitleSet
+
+from fractions import Fraction
+
+cdef class Decoder(CodecContext):
+
+    def __init__(self, str codec_name not None):
+
+        cdef lib.AVCodec *codec
+        codec = lib.avcodec_find_decoder_by_name(codec_name)
+        if not codec:
+            codec_descriptor = lib.avcodec_descriptor_get_by_name(codec_name)
+            if codec_descriptor:
+                codec = lib.avcodec_find_decoder(codec_descriptor.id)
+        if not codec:
+            raise ValueError("unknown encoding codec: %r" % codec_name)
+
+        self.ptr = lib.avcodec_alloc_context3(codec)
+        if not self.ptr:
+            raise MemoryError("cannot allocate AVCodecContext")
+
+        err_check(lib.avcodec_get_context_defaults3(self.ptr, codec))
+
+        # older version of ffmpeg (2.2.4) don't set codec ptr
+        if not self.ptr.codec:
+            self.ptr.codec = codec
+
+        self.options = {}
+        self._container = None
+        self.next_frame = None
+
+    cdef decode_video_frame(self, Packet packet, int *data_consumed):
+        if not self.next_frame:
+             self.next_frame = alloc_video_frame()
+
+        cdef int completed_frame = 0
+        cdef int ret = 0
+
+        if not packet:
+            packet = Packet()
+
+        cdef lib.AVPacket *packet_ptr = &packet.struct
+
+        with nogil:
+             ret = lib.avcodec_decode_video2(self.ptr, self.next_frame.ptr, &completed_frame, packet_ptr)
+        data_consumed[0] = err_check(ret)
+
+        if not completed_frame:
+             return
+
+        cdef VideoFrame frame = self.next_frame
+        self.next_frame = None
+
+        frame._init_properties()
+
+        return frame
+
+    cdef decode_audio_frame(self, Packet packet, int *data_consumed):
+        if not self.next_frame:
+             self.next_frame = alloc_audio_frame()
+
+        cdef int completed_frame = 0
+        cdef int ret = 0
+
+        if not packet:
+            packet = Packet()
+
+        cdef lib.AVPacket *packet_ptr = &packet.struct
+
+        with nogil:
+            ret = lib.avcodec_decode_audio4(self.ptr, self.next_frame.ptr, &completed_frame, packet_ptr)
+        data_consumed[0] = err_check(ret)
+
+        if not completed_frame:
+            return
+
+        cdef AudioFrame frame = self.next_frame
+        self.next_frame = None
+
+        frame._init_properties()
+
+        return frame
+
+    cdef decode_subtitle_frame(self, Packet packet, int *data_consumed):
+
+        cdef int completed_frame = 0
+        cdef int ret = 0
+        cdef SubtitleProxy proxy = SubtitleProxy()
+        if not packet:
+            packet = Packet()
+
+        cdef lib.AVPacket *packet_ptr = &packet.struct
+
+        with nogil:
+            ret = lib.avcodec_decode_subtitle2(self.ptr, &proxy.struct, &completed_frame, packet_ptr)
+        err_check(ret)
+        data_consumed[0] = packet.size
+
+        if not completed_frame:
+            return
+
+        return SubtitleSet(proxy)
+
+    cdef decode_one(self, Packet packet, int *data_consumed):
+        if self.ptr.codec_type == lib.AVMEDIA_TYPE_VIDEO:
+            return self.decode_video_frame(packet, data_consumed)
+        elif self.ptr.codec_type == lib.AVMEDIA_TYPE_AUDIO:
+            return self.decode_audio_frame(packet, data_consumed)
+        elif self.ptr.codec_type == lib.AVMEDIA_TYPE_SUBTITLE:
+            return self.decode_subtitle_frame(packet, data_consumed)
+        else:
+            raise NotImplementedError("%s decoding not implemented yet" % self.type)
+
+    def decode(self, Packet packet=None):
+        if not lib.avcodec_is_open(self.ptr):
+            self.open()
+
+        cdef int data_consumed = 0
+        cdef uint8_t *original_data = packet.struct.data if packet else NULL
+        cdef int      original_size = packet.struct.size if packet else 0
+
+        try:
+            if packet is None:
+                frame = self.decode_one(None, &data_consumed)
+                while frame:
+                    yield frame
+                    frame = self.decode_one(None, &data_consumed)
+
+            else:
+                while packet.struct.size > 0:
+                    frame = self.decode_one(packet, &data_consumed)
+                    if frame:
+                        yield frame
+                    packet.struct.size -= data_consumed
+                    packet.struct.data += data_consumed
+
+        finally:
+            if packet:
+                packet.struct.size = original_size
+                packet.struct.data = original_data
+
+    def flush(self):
+        for frame in self.decode(None):
+            yield frame

--- a/av/encode.pxd
+++ b/av/encode.pxd
@@ -1,0 +1,12 @@
+cimport libav as lib
+
+from codec cimport CodecContext
+
+from av.video.frame cimport VideoFrame
+from av.audio.frame cimport AudioFrame
+from av.audio.fifo cimport AudioFifo
+
+cdef class Encoder(CodecContext):
+    cdef AudioFifo fifo
+    cdef encode_video_frame(self, VideoFrame frame=*)
+    cdef encode_audio_frame(self, AudioFrame frame=*)

--- a/av/encode.pyx
+++ b/av/encode.pyx
@@ -1,0 +1,128 @@
+from av.utils cimport err_check
+from av.packet cimport Packet
+from av.frame cimport Frame
+
+from fractions import Fraction
+
+cdef class Encoder(CodecContext):
+
+    def __init__(self, str codec_name not None):
+
+        cdef lib.AVCodec *codec
+        codec = lib.avcodec_find_encoder_by_name(codec_name)
+        if not codec:
+            codec_descriptor = lib.avcodec_descriptor_get_by_name(codec_name)
+            if codec_descriptor:
+                codec = lib.avcodec_find_encoder(codec_descriptor.id)
+        if not codec:
+            raise ValueError("unknown encoding codec: %r" % codec_name)
+
+        self.ptr = lib.avcodec_alloc_context3(codec)
+        if not self.ptr:
+            raise MemoryError("cannot allocate AVCodecContext")
+
+        err_check(lib.avcodec_get_context_defaults3(self.ptr, codec))
+
+        # older version of ffmpeg (2.2.4) don't set codec ptr
+        if not self.ptr.codec:
+            self.ptr.codec = codec
+
+        self.fifo = None
+        self._container = None
+        self.options = {}
+
+    cdef encode_video_frame(self, VideoFrame frame=None):
+        cdef int got_output = 0
+        cdef int ret = 0
+        cdef lib.AVFrame *frame_ptr = frame.ptr if frame else NULL #Null for flush
+        cdef Packet packet = Packet()
+
+        if frame:
+            if frame.ptr.format != self.ptr.pix_fmt:
+                raise ValueError('incorrect pix_fmt: "%s" expected: "%s"' %
+                                         (frame.format.name, self.pix_fmt))
+            if frame.ptr.width != self.ptr.width or frame.ptr.height != self.ptr.height:
+                raise ValueError('incorrect size: "%dx%d" expected: "%dx%d"' %
+                                         (frame.ptr.width,frame.ptr.height,
+                                          self.ptr.width,self.ptr.height))
+
+        with nogil:
+            ret = lib.avcodec_encode_video2(self.ptr, &packet.struct, frame_ptr, &got_output)
+        err_check(ret)
+
+        if got_output:
+            return packet
+
+    cdef encode_audio_frame(self, AudioFrame frame=None):
+        cdef int got_output = 0
+        cdef int ret = 0
+        cdef lib.AVFrame *frame_ptr = frame.ptr if frame else NULL #Null for flush
+        cdef Packet packet = Packet()
+
+        with nogil:
+            ret = lib.avcodec_encode_audio2(self.ptr, &packet.struct, frame_ptr, &got_output)
+        err_check(ret)
+
+        if got_output:
+            return packet
+
+    def process_audio_frame(self, AudioFrame frame=None):
+
+        # use fifo if codec doesn't support variable frame size
+        cdef bint use_fifo = not self.ptr.codec.capabilities & lib.CODEC_CAP_VARIABLE_FRAME_SIZE
+        cdef int frame_size = self.ptr.frame_size
+
+        if frame:
+            if frame.ptr.format != self.ptr.sample_fmt:
+                raise ValueError('incorrect sample_fmt: "%s" expected: "%s"' %
+                                         (frame.format.name, self.sample_fmt))
+
+            if frame.ptr.sample_rate != self.ptr.sample_rate:
+                raise ValueError("incorrect sample rate: %d expected: %d" %
+                                          (frame.ptr.sample_rate, self.sample_rate))
+
+            if frame.nb_channels != self.ptr.channels:
+                raise ValueError("incorrect channel count: %d expected: %d" %
+                                        (frame.nb_channels, self.ptr.channels))
+
+            if use_fifo:
+                if not self.fifo:
+                    self.fifo = AudioFifo()
+                self.fifo.write(frame)
+            else:
+                yield frame
+
+        if use_fifo:
+            for f in self.fifo.iter(frame_size, partial = frame is None):
+                yield f
+
+    def encode(self, Frame frame=None):
+        if not lib.avcodec_is_open(self.ptr):
+            self.open()
+
+        if self.ptr.codec_type == lib.AVMEDIA_TYPE_VIDEO:
+            packet = self.encode_video_frame(frame)
+            if frame is None:
+                while packet:
+                    yield packet
+                    packet =  self.encode_video_frame(None)
+            elif packet:
+                yield packet
+
+        elif self.ptr.codec_type == lib.AVMEDIA_TYPE_AUDIO:
+            for f in self.process_audio_frame(frame):
+                packet = self.encode_audio_frame(f)
+                if packet:
+                    yield packet
+
+            if frame is None:
+                packet = self.encode_audio_frame(None)
+                while packet:
+                    yield packet
+                    packet = self.encode_audio_frame(None)
+        else:
+            raise NotImplementedError("%s encoding not implemented yet" % self.type)
+
+    def flush(self):
+        for packet in self.encode(None):
+            yield packet

--- a/av/packet.pyx
+++ b/av/packet.pyx
@@ -1,20 +1,22 @@
 cimport libav as lib
 from av.utils cimport avrational_to_faction
+from av.utils cimport err_check
 
+cdef class Packet(Buffer):
 
-cdef class Packet(object):
-    
     """A packet of encoded data within a :class:`~av.format.Stream`.
 
     This may, or may not include a complete object within a stream.
     :meth:`decode` must be called to extract encoded data.
 
     """
-    def __init__(self):
+    def __init__(self, size_t size=0):
         with nogil:
             lib.av_init_packet(&self.struct)
             self.struct.data = NULL
             self.struct.size = 0
+        if size:
+            err_check(lib.av_new_packet(&self.struct, size))
 
     def __dealloc__(self):
         with nogil: lib.av_free_packet(&self.struct)
@@ -22,7 +24,7 @@ cdef class Packet(object):
     def __repr__(self):
         return '<av.%s of #%d, dts=%s, pts=%s at 0x%x>' % (
             self.__class__.__name__,
-            self.stream.index,
+            self.stream.index if self.stream else 0,
             self.dts,
             self.pts,
             id(self),

--- a/av/stream.pxd
+++ b/av/stream.pxd
@@ -5,7 +5,7 @@ cimport libav as lib
 from av.container.core cimport Container, ContainerProxy
 from av.frame cimport Frame
 from av.packet cimport Packet
-
+from av.codec cimport CodecContext
 
 cdef class Stream(object):
     
@@ -16,6 +16,8 @@ cdef class Stream(object):
     cdef lib.AVStream *_stream
     cdef readonly dict metadata
 
+    cdef readonly CodecContext coder
+
     # CodecContext attributes.
     cdef lib.AVCodecContext *_codec_context
     cdef lib.AVCodec *_codec
@@ -24,7 +26,6 @@ cdef class Stream(object):
     # Private API.
     cdef _init(self, Container, lib.AVStream*)
     cdef _setup_frame(self, Frame)
-    cdef _decode_one(self, lib.AVPacket*, int *data_consumed)
 
     # Public API.
     cpdef decode(self, Packet packet, int count=?)

--- a/av/subtitles/stream.pyx
+++ b/av/subtitles/stream.pyx
@@ -7,15 +7,4 @@ from av.utils cimport err_check
 
 
 cdef class SubtitleStream(Stream):
-    
-    cdef _decode_one(self, lib.AVPacket *packet, int *data_consumed):
-        
-        cdef SubtitleProxy proxy = SubtitleProxy()
-        
-        cdef int completed_frame = 0
-        data_consumed[0] = err_check(lib.avcodec_decode_subtitle2(self._codec_context, &proxy.struct, &completed_frame, packet))
-        if not completed_frame:
-            return
-        
-        return SubtitleSet(proxy)
-
+    pass

--- a/av/video/stream.pxd
+++ b/av/video/stream.pxd
@@ -12,9 +12,6 @@ cdef class VideoStream(Stream):
     cdef _build_format(self)
 
     cdef readonly int buffer_size
-    
-    # Hold onto the frames that we will decode until we have a full one.
-    cdef VideoFrame next_frame
 
     # Common reformatter shared with all frames since it is likely to get reused.
     cdef VideoReformatter reformatter
@@ -25,5 +22,3 @@ cdef class VideoStream(Stream):
     cdef int last_h
     
     cdef int encoded_frame_count
-    
-    cpdef encode(self, VideoFrame frame=*)

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -99,8 +99,8 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
         int profile
 
         AVFrame* coded_frame
-        
-        int bit_rate
+
+        int64_t bit_rate
         int bit_rate_tolerance
         int mb_decision
         
@@ -148,7 +148,9 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
         
         # User Data
         void *opaque
-    
+
+    cdef AVCodecContext* avcodec_alloc_context3(AVCodec *codec)
+    cdef void avcodec_free_context(AVCodecContext **pavctx)
     cdef int avcodec_copy_context(AVCodecContext *dst, const AVCodecContext *src)
 
     cdef struct AVCodecDescriptor:

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -293,7 +293,8 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
     
     cdef void av_free_packet(AVPacket*)
     cdef void av_init_packet(AVPacket*)
-    cdef void av_packet_unref(AVPacket *pkt)   
+    cdef int av_new_packet(AVPacket*, int)
+    cdef void av_packet_unref(AVPacket *pkt)
     cdef int av_copy_packet(AVPacket *dst, AVPacket *src)
     cdef int av_dup_packet(AVPacket *pkt)
 

--- a/include/libavcodec/avcodec.pyav.h
+++ b/include/libavcodec/avcodec.pyav.h
@@ -10,6 +10,22 @@
 
 #endif
 
+#ifndef PYAV_HAVE_AVCODEC_FREE_CONTEXT
+    void avcodec_free_context(AVCodecContext **pavctx)
+    {
+        AVCodecContext *avctx = *pavctx;
+
+        if (!avctx)
+            return;
+
+        avcodec_close(avctx);
+
+        av_freep(&avctx->extradata);
+        av_freep(&avctx->subtitle_header);
+
+        av_freep(pavctx);
+    }
+#endif
 
 #ifdef PYAV_HAVE_FFMPEG
 

--- a/setup.py
+++ b/setup.py
@@ -436,6 +436,7 @@ class ReflectCommand(Command):
             # This we actually care about:
             'av_calloc',
             'av_frame_get_best_effort_timestamp',
+            'avcodec_free_context',
             'avformat_alloc_output_context2',
             'avformat_close_input',
 

--- a/tests/test_coders.py
+++ b/tests/test_coders.py
@@ -1,0 +1,280 @@
+from .common import *
+import av
+from fractions import Fraction
+from av.buffer import Buffer
+from av.packet import Packet
+from av.audio.resampler import AudioResampler
+
+def iter_frames(container, stream):
+    for packet in container.demux(stream):
+        for frame in packet.decode():
+            yield frame
+
+def iter_raw_frames(path, packet_sizes, decoder):
+    with open(path, 'rb') as f:
+        for size in packet_sizes:
+            packet = Packet(size)
+            read_size = f.readinto(packet)
+            if not read_size:
+                break
+            for frame in decoder.decode(packet):
+                yield frame
+
+        for frame in decoder.flush():
+            yield frame
+
+class TestCoders(TestCase):
+
+    def test_encoding_png(self):
+        self.image_sequence_encode('png')
+
+    def test_encoding_mjpeg(self):
+        self.image_sequence_encode('mjpeg')
+
+    def test_encoding_tiff(self):
+        self.image_sequence_encode('tiff')
+
+    def image_sequence_encode(self, codec):
+
+        if not codec in av.codec.codecs_availible:
+            raise SkipTest()
+
+        container = av.open(fate_suite('h264/interlaced_crop.mp4'))
+        video_stream = next(s for s in container.streams if s.type == 'video')
+
+        width =  640
+        height = 480
+
+        encoder = av.Encoder(codec)
+
+        pix_fmt = encoder.codec.video_formats[0].name
+
+        encoder.width = width
+        encoder.height = height
+        encoder.time_base = Fraction(24000, 1001)
+        encoder.pix_fmt = pix_fmt
+        encoder.open()
+
+        frame_count = 1
+        path_list = []
+        for frame in iter_frames(container, video_stream):
+            new_frame = frame.reformat(width, height, pix_fmt)
+            for i, new_packet in enumerate(encoder.encode(new_frame)):
+                path = self.sandboxed('%s/encoder.%04d.%s' % (codec,
+                                                              frame_count,
+                                                              codec if codec != 'mjpeg' else 'jpg'))
+                path_list.append(path)
+                with open(path, 'wb') as f:
+                    f.write(new_packet)
+                frame_count += 1
+            if frame_count > 5:
+                break
+
+        decoder = av.Decoder(codec)
+        decoder.open()
+
+        for path in path_list:
+            with open(path, 'rb') as f:
+                size = os.fstat(f.fileno()).st_size
+                packet = Packet(size)
+                size = f.readinto(packet)
+                frame = next(decoder.decode(packet))
+                self.assertEqual(frame.width, width)
+                self.assertEqual(frame.height, height)
+                self.assertEqual(frame.format.name, pix_fmt)
+
+    def test_encoding_h264(self):
+        self.video_encoding('libx264', {'crf':'19'})
+
+    def test_encoding_mpeg4(self):
+        self.video_encoding('mpeg4')
+
+    def test_encoding_mpeg1video(self):
+        self.video_encoding('mpeg1video')
+
+    def test_encoding_dvvideo(self):
+        options = {'pix_fmt':'yuv411p',
+                   'width':720,
+                   'height':480}
+        self.video_encoding('dvvideo', options)
+
+    def test_encoding_dnxhd(self):
+        options = {'b':'90M', #bitrate
+                   'pix_fmt':'yuv422p',
+                   'width':  1920,
+                   'height': 1080,
+                   'time_base': Fraction(30000, 1001),
+                   'max_frames': 5}
+        self.video_encoding('dnxhd', options)
+
+    def video_encoding(self, codec, options = {}):
+
+        if not codec in av.codec.codecs_availible:
+            raise SkipTest()
+
+        container = av.open(fate_suite('h264/interlaced_crop.mp4'))
+        video_stream = next(s for s in container.streams if s.type == 'video')
+
+        pix_fmt = options.get('pix_fmt', 'yuv420p')
+        width =  options.get('width', 640)
+        height = options.get('height', 480)
+
+        max_frames = options.get('max_frames', 1000)
+        time_base = options.get('time_base', Fraction(24000, 1001))
+
+        for key in ('pix_fmt', 'width', 'height', 'max_frames', 'time_base'):
+            if key in options:
+                del options[key]
+
+        encoder = av.Encoder(codec)
+        encoder.width = width
+        encoder.height = height
+        encoder.time_base = time_base
+        encoder.pix_fmt = pix_fmt
+        encoder.options = options
+        encoder.open()
+
+        path = self.sandboxed('encoder.%s' % codec)
+        packet_sizes = []
+        frame_count = 0
+        test_bad = True
+        with open(path, 'wb') as f:
+            for frame in iter_frames(container, video_stream):
+
+                if frame_count > max_frames:
+                    break
+
+                if test_bad:
+                    bad_frame = frame.reformat(width, 100, pix_fmt)
+                    with self.assertRaises(ValueError):
+                        next(encoder.encode(bad_frame))
+
+                    bad_frame = frame.reformat(100, height, pix_fmt)
+                    with self.assertRaises(ValueError):
+                        next(encoder.encode(bad_frame))
+
+                    bad_frame = frame.reformat(width, height, "rgb24")
+                    with self.assertRaises(ValueError):
+                        next(encoder.encode(bad_frame))
+                    test_bad = False
+
+                new_frame = frame.reformat(width, height, pix_fmt)
+                for new_packet in encoder.encode(new_frame):
+                    packet_sizes.append(new_packet.size)
+                    f.write(new_packet)
+                frame_count += 1
+
+            for new_packet in encoder.flush():
+                packet_sizes.append(new_packet.size)
+                f.write(new_packet)
+
+        dec_codec = codec
+        if codec == 'libx264':
+            dec_codec = 'h264'
+
+        decoder = av.Decoder(dec_codec)
+        decoder.open()
+
+        decoded_frame_count = 0
+        for frame in iter_raw_frames(path, packet_sizes, decoder):
+            decoded_frame_count += 1
+            self.assertEqual(frame.width, width)
+            self.assertEqual(frame.height, height)
+            self.assertEqual(frame.format.name, pix_fmt)
+
+        self.assertEqual(decoded_frame_count, frame_count)
+
+    def test_encoding_pcm_s24le(self):
+        self.audio_encoding('pcm_s24le')
+
+    def test_encoding_aac(self):
+        self.audio_encoding('aac')
+
+    def test_encoding_mp2(self):
+        self.audio_encoding('mp2')
+
+    def audio_encoding(self, codec):
+
+        if not codec in av.codec.codecs_availible:
+            raise SkipTest()
+
+        encoder = av.Encoder(codec)
+        if encoder.codec.experimental:
+            raise SkipTest()
+
+        sample_fmt  = encoder.codec.audio_formats[-1].name
+
+        sample_rate = 48000
+        channel_layout = "stereo"
+        channels = 2
+        encoder.time_base = sample_rate
+        encoder.sample_rate = sample_rate
+        encoder.sample_fmt = sample_fmt
+        encoder.channels = channels
+        encoder.open()
+
+        resampler = AudioResampler(sample_fmt, channel_layout, sample_rate)
+
+        container = av.open(fate_suite('audio-reference/chorusnoise_2ch_44kHz_s16.wav'))
+        audio_stream = next(s for s in container.streams if s.type == 'audio')
+        path = self.sandboxed('encoder.%s' % codec)
+
+        samples = 0
+        packet_sizes = []
+
+        test_bad = True
+
+        with open(path, 'w') as f:
+            for frame in iter_frames(container, audio_stream):
+
+                if test_bad:
+                    bad_resampler = AudioResampler(sample_fmt, "mono", sample_rate)
+                    bad_frame = bad_resampler.resample(frame)
+                    with self.assertRaises(ValueError):
+                        next(encoder.encode(bad_frame))
+
+                    bad_resampler = AudioResampler(sample_fmt, channel_layout, 3000)
+                    bad_frame = bad_resampler.resample(frame)
+
+                    with self.assertRaises(ValueError):
+                        next(encoder.encode(bad_frame))
+
+                    bad_resampler = AudioResampler('u8', channel_layout, 3000)
+                    bad_frame = bad_resampler.resample(frame)
+
+                    with self.assertRaises(ValueError):
+                        next(encoder.encode(bad_frame))
+
+                    test_bad = False
+
+                resampled_frame = resampler.resample(frame)
+                samples += resampled_frame.samples
+                for new_packet in encoder.encode(resampled_frame):
+                    # bytearray because python can
+                    # freaks out if the first byte is NULL
+                    f.write(bytearray(new_packet))
+                    packet_sizes.append(new_packet.size)
+
+            for new_packet in encoder.flush():
+                packet_sizes.append(new_packet.size)
+                f.write(bytearray(new_packet))
+
+        decoder = av.Decoder(codec)
+        decoder.time_base = sample_rate
+        decoder.sample_rate = sample_rate
+        decoder.sample_fmt = sample_fmt
+        decoder.channels = channels
+        decoder.open()
+
+        result_samples = 0
+
+        # should have more asserts but not sure what to check
+        # libav and ffmpeg give different results
+        # so can really use checksums
+        for frame in iter_raw_frames(path, packet_sizes, decoder):
+            result_samples += frame.samples
+            self.assertEqual(frame.rate, sample_rate)
+            self.assertEqual(len(frame.layout.channels), channels)
+
+# import logging
+# logging.basicConfig()


### PR DESCRIPTION
The following pull request adds new `Encoder` and `Decoder` classes. This allows one to setup a encoder/decoder without a AVFormatContext. Currently its a little verbose to setup, but that can be made easier in future patches.

here is a quick example that generates mpeg4 packets:

``` python
import av
# setup encoder
encoder = av.Encoder("mpeg4")
encoder.width = 640
encoder.height = 480
encoder.time_base = "25/1"
encoder.pix_fmt = "yuv420p"

# create a blank frame
frame = av.VideoFrame(640, 480, 'yuv420p')

# encode 10 frame
for x in range(10):
    for packet in encoder.encode(frame):
        print packet

# flush encoder
for packet in encoder.flush():
    print packet
```

The new classes are also handy for reading and writing image formats. We use could them to  add read and write methods on the `VideoFrame` object that supports all the formats that libavcodec supports.  There are some added tests that show how to do this.

The last patch in the series integrates the new class in the Stream object instead of directly calling libavcodec. As a first step, I tried to do it in a way did that doesn't break anything. There is currently a lot of shared functionality currently between the `Stream` object and the `CodecContext` object. I like to clean that up a bit more, but again this is just the first step.
