### PR TITLE
avcodec_receive_*(): EAGAIN can be -35, but also -11

### DIFF
--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -227,7 +227,7 @@ cdef class CodecContext(object):
         cdef Frame frame = self._next_frame
 
         cdef int res = lib.avcodec_receive_frame(self.ptr, frame.ptr)
-        if res == -35 or res == lib.AVERROR_EOF: # EAGAIN
+        if res in (-35, -11) or res == lib.AVERROR_EOF: # EAGAIN
             return
         err_check(res)
 
@@ -241,7 +241,7 @@ cdef class CodecContext(object):
         cdef Packet packet = Packet()
             
         cdef int res = lib.avcodec_receive_packet(self.ptr, &packet.struct)
-        if res == -35 or res == lib.AVERROR_EOF: # EAGAIN
+        if res in (-35, -11) or res == lib.AVERROR_EOF: # EAGAIN
             return
         err_check(res)
 

--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -11,7 +11,7 @@ from av.utils cimport err_check, avdict_to_dict, avrational_to_faction, to_avrat
 from av.dictionary cimport _Dictionary
 from av.dictionary import Dictionary
 
-
+from errno import EAGAIN
 
 cdef object _cinit_sentinel = object()
 
@@ -227,7 +227,7 @@ cdef class CodecContext(object):
         cdef Frame frame = self._next_frame
 
         cdef int res = lib.avcodec_receive_frame(self.ptr, frame.ptr)
-        if res in (-35, -11) or res == lib.AVERROR_EOF: # EAGAIN
+        if res == -EAGAIN or res == lib.AVERROR_EOF: # EAGAIN
             return
         err_check(res)
 
@@ -241,7 +241,7 @@ cdef class CodecContext(object):
         cdef Packet packet = Packet()
             
         cdef int res = lib.avcodec_receive_packet(self.ptr, &packet.struct)
-        if res in (-35, -11) or res == lib.AVERROR_EOF: # EAGAIN
+        if res == -EAGAIN or res == lib.AVERROR_EOF: # EAGAIN
             return
         err_check(res)
 


### PR DESCRIPTION
I've got ffmpeg 3.3.1 on win7 x64 and cpython 3.6.1 and this caused trouble. renaming the constants to something obvious might be a good idea, but this got it working for me at least.