### PR TITLE
Better option handling, add filter iterator, expose filter options

### DIFF
--- a/av/filter/__init__.py
+++ b/av/filter/__init__.py
@@ -1,2 +1,2 @@
-from .filter import Filter
+from .filter import Filter, FiltersIter
 from .graph import Graph

--- a/av/filter/filter.pxd
+++ b/av/filter/filter.pxd
@@ -4,9 +4,9 @@ cimport libav as lib
 cdef class Filter(object):
 
     cdef lib.AVFilter *ptr
-    
+
     cdef object _inputs
     cdef object _outputs
-    
-    
+
+
 cdef Filter wrap_filter(lib.AVFilter *ptr)

--- a/av/filter/filter.pxd
+++ b/av/filter/filter.pxd
@@ -1,5 +1,7 @@
 cimport libav as lib
 
+from av.descriptor cimport Descriptor
+
 
 cdef class Filter(object):
 
@@ -7,6 +9,12 @@ cdef class Filter(object):
 
     cdef object _inputs
     cdef object _outputs
+    cdef Descriptor _descriptor
 
 
 cdef Filter wrap_filter(lib.AVFilter *ptr)
+
+
+cdef class FiltersIter(object):
+
+    cdef lib.AVFilter *ptr

--- a/av/filter/filter.pyx
+++ b/av/filter/filter.pyx
@@ -22,19 +22,19 @@ cdef class Filter(object):
         self.ptr = lib.avfilter_get_by_name(name)
         if not self.ptr:
             raise ValueError('no filter %s' % name)
-    
+
     property name:
         def __get__(self):
             return self.ptr.name
-    
+
     property description:
         def __get__(self):
             return self.ptr.description
-    
+
     property dynamic_inputs:
         def __get__(self):
             return bool(self.ptr.flags & lib.AVFILTER_FLAG_DYNAMIC_INPUTS)
-            
+
     property dynamic_outputs:
         def __get__(self):
             return bool(self.ptr.flags & lib.AVFILTER_FLAG_DYNAMIC_OUTPUTS)
@@ -44,7 +44,7 @@ cdef class Filter(object):
             if self._inputs is None:
                 self._inputs = alloc_filter_pads(self, self.ptr.inputs, True)
             return self._inputs
-    
+
     property outputs:
         def __get__(self):
             if self._outputs is None:

--- a/av/option.pxd
+++ b/av/option.pxd
@@ -4,7 +4,15 @@ cimport libav as lib
 cdef class Option(object):
 
     cdef lib.AVOption *ptr
+    cdef readonly tuple choices # choices tuple
 
 
-cdef Option wrap_option(lib.AVOption *ptr)
+cdef class OptionChoice(object):
+
+    cdef lib.AVOption *ptr
+
+
+cdef Option wrap_option(tuple choices, lib.AVOption *ptr)
+
+cdef OptionChoice wrap_option_choice(lib.AVOption *ptr)
 

--- a/av/option.pyx
+++ b/av/option.pyx
@@ -12,23 +12,23 @@ cdef Option wrap_option(lib.AVOption *ptr):
 
 
 cdef dict _TYPE_NAMES = {
-    lib.AV_OPT_TYPE_FLAGS: 'FLAGS',   
-    lib.AV_OPT_TYPE_INT: 'INT',     
-    lib.AV_OPT_TYPE_INT64: 'INT64',   
-    lib.AV_OPT_TYPE_DOUBLE: 'DOUBLE',  
-    lib.AV_OPT_TYPE_FLOAT: 'FLOAT',   
-    lib.AV_OPT_TYPE_STRING: 'STRING',  
-    lib.AV_OPT_TYPE_RATIONAL: 'RATIONAL',    
-    lib.AV_OPT_TYPE_BINARY: 'BINARY',  
+    lib.AV_OPT_TYPE_FLAGS: 'FLAGS',
+    lib.AV_OPT_TYPE_INT: 'INT',
+    lib.AV_OPT_TYPE_INT64: 'INT64',
+    lib.AV_OPT_TYPE_DOUBLE: 'DOUBLE',
+    lib.AV_OPT_TYPE_FLOAT: 'FLOAT',
+    lib.AV_OPT_TYPE_STRING: 'STRING',
+    lib.AV_OPT_TYPE_RATIONAL: 'RATIONAL',
+    lib.AV_OPT_TYPE_BINARY: 'BINARY',
     #lib.AV_OPT_TYPE_DICT: 'DICT', # Recent addition; does not always exist.
-    lib.AV_OPT_TYPE_CONST: 'CONST',   
-    #lib.AV_OPT_TYPE_IMAGE_SIZE: 'IMAGE_SIZE',  
-    #lib.AV_OPT_TYPE_PIXEL_FMT: 'PIXEL_FMT',   
-    #lib.AV_OPT_TYPE_SAMPLE_FMT: 'SAMPLE_FMT',  
-    #lib.AV_OPT_TYPE_VIDEO_RATE: 'VIDEO_RATE',  
-    #lib.AV_OPT_TYPE_DURATION: 'DURATION',    
-    #lib.AV_OPT_TYPE_COLOR: 'COLOR',   
-    #lib.AV_OPT_TYPE_CHANNEL_LAYOUT: 'CHANNEL_LAYOUT',  
+    lib.AV_OPT_TYPE_CONST: 'CONST',
+    #lib.AV_OPT_TYPE_IMAGE_SIZE: 'IMAGE_SIZE',
+    #lib.AV_OPT_TYPE_PIXEL_FMT: 'PIXEL_FMT',
+    #lib.AV_OPT_TYPE_SAMPLE_FMT: 'SAMPLE_FMT',
+    #lib.AV_OPT_TYPE_VIDEO_RATE: 'VIDEO_RATE',
+    #lib.AV_OPT_TYPE_DURATION: 'DURATION',
+    #lib.AV_OPT_TYPE_COLOR: 'COLOR',
+    #lib.AV_OPT_TYPE_CHANNEL_LAYOUT: 'CHANNEL_LAYOUT',
 }
 
 

--- a/include/libavfilter/avfilter.pxd
+++ b/include/libavfilter/avfilter.pxd
@@ -4,7 +4,7 @@ cdef extern from "libavfilter/avfilter.h" nogil:
     cdef int   avfilter_version()
     cdef char* avfilter_configuration()
     cdef char* avfilter_license()
-    
+
     cdef void avfilter_register_all()
 
     cdef struct AVFilterPad:
@@ -22,7 +22,7 @@ cdef extern from "libavfilter/avfilter.h" nogil:
         const char *description
 
         const int flags
-        
+
         const AVFilterPad *inputs
         const AVFilterPad *outputs
 
@@ -35,7 +35,7 @@ cdef extern from "libavfilter/avfilter.h" nogil:
     cdef AVFilter* avfilter_get_by_name(const char *name)
 
     cdef struct AVFilterLink # Defined later.
-    
+
     cdef struct AVFilterContext:
 
         AVClass *av_class
@@ -46,7 +46,7 @@ cdef extern from "libavfilter/avfilter.h" nogil:
         unsigned int nb_inputs
         AVFilterPad *input_pads
         AVFilterLink **inputs
-        
+
         unsigned int nb_outputs
         AVFilterPad *output_pads
         AVFilterLink **outputs
@@ -56,12 +56,12 @@ cdef extern from "libavfilter/avfilter.h" nogil:
     cdef void avfilter_free(AVFilterContext*)
 
     cdef struct AVFilterLink:
-        
+
         AVFilterContext *src
         AVFilterPad *srcpad
         AVFilterContext *dst
         AVFilterPad *dstpad
-        
+
         AVMediaType Type
         int w
         int h
@@ -70,4 +70,3 @@ cdef extern from "libavfilter/avfilter.h" nogil:
         int sample_rate
         int format
         AVRational time_base
-        

--- a/include/libavfilter/avfilter.pxd
+++ b/include/libavfilter/avfilter.pxd
@@ -34,6 +34,8 @@ cdef extern from "libavfilter/avfilter.h" nogil:
 
     cdef AVFilter* avfilter_get_by_name(const char *name)
 
+    cdef const AVFilter* avfilter_next(const AVFilter *prev)
+
     cdef struct AVFilterLink # Defined later.
 
     cdef struct AVFilterContext:

--- a/include/libavutil/avutil.pxd
+++ b/include/libavutil/avutil.pxd
@@ -227,15 +227,17 @@ cdef extern from "libavutil/opt.h" nogil:
         AV_OPT_TYPE_STRING
         AV_OPT_TYPE_RATIONAL
         AV_OPT_TYPE_BINARY
-        #AV_OPT_TYPE_DICT # Missing from FFmpeg
+        AV_OPT_TYPE_DICT # Missing from FFmpeg
+        AV_OPT_TYPE_UINT64 # previously missing?
         AV_OPT_TYPE_CONST
-        #AV_OPT_TYPE_IMAGE_SIZE # Missing from LibAV
-        #AV_OPT_TYPE_PIXEL_FMT # Missing from LibAV
-        #AV_OPT_TYPE_SAMPLE_FMT # Missing from LibAV
-        #AV_OPT_TYPE_VIDEO_RATE # Missing from FFmpeg
-        #AV_OPT_TYPE_DURATION # Missing from FFmpeg
-        #AV_OPT_TYPE_COLOR # Missing from FFmpeg
-        #AV_OPT_TYPE_CHANNEL_LAYOUT # Missing from FFmpeg
+        AV_OPT_TYPE_IMAGE_SIZE # Missing from LibAV
+        AV_OPT_TYPE_PIXEL_FMT # Missing from LibAV
+        AV_OPT_TYPE_SAMPLE_FMT # Missing from LibAV
+        AV_OPT_TYPE_VIDEO_RATE # Missing from FFmpeg
+        AV_OPT_TYPE_DURATION # Missing from FFmpeg
+        AV_OPT_TYPE_COLOR # Missing from FFmpeg
+        AV_OPT_TYPE_CHANNEL_LAYOUT # Missing from FFmpeg
+        AV_OPT_TYPE_BOOL # previously missing?
 
     cdef struct AVOption_default_val:
         int64_t i64


### PR DESCRIPTION
Options:
* don't add ```AV_OPT_TYPE_CONST``` options to ```Descriptor.options```, instead implement ```OptionChoice``` and ```Option.choices``` (work just like [print_options in ffmpeg](https://github.com/FFmpeg/FFmpeg/blob/master/doc/print_options.c)
* add ```min```, ```max```, ```default_val``` to ```Option```
* from what I see, all option types are now declared in both ffmpeg and libav but this depends on which versions PyAV is targeting. Any suggestions?

Filters:
* add ```FiltersIter``` to iterate through all registered filters using ```avfilter_next```
* expose ```descriptor``` and it's ```options``` in ```Filter```

Considerations:
* maybe it would make sense to use editorconfig because whitespace is rather messy at places