### PR TITLE
Support specifying metadata character encoding

### DIFF
--- a/av/container/core.pxd
+++ b/av/container/core.pxd
@@ -17,6 +17,8 @@ cdef class ContainerProxy(object):
     cdef flush_buffers(self)
 
     cdef str name
+    cdef str encoding
+    cdef str errors
 
     # File-like source.
     cdef object file
@@ -50,3 +52,6 @@ cdef class Container(object):
 
     cdef readonly StreamContainer streams
     cdef readonly dict metadata
+
+    cdef str encoding
+    cdef str errors

--- a/av/container/input.pyx
+++ b/av/container/input.pyx
@@ -49,7 +49,7 @@ cdef class InputContainer(Container):
         for i in range(self.proxy.ptr.nb_streams):
             self.streams.add_stream(wrap_stream(self, self.proxy.ptr.streams[i]))
 
-        self.metadata = avdict_to_dict(self.proxy.ptr.metadata)
+        self.metadata = avdict_to_dict(self.proxy.ptr.metadata, self.encoding, self.errors)
 
     property start_time:
         def __get__(self): return self.proxy.ptr.start_time

--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -145,7 +145,8 @@ cdef class OutputContainer(Container):
             err_check(lib.avio_open(&self.proxy.ptr.pb, name, lib.AVIO_FLAG_WRITE))
 
         # Copy the metadata dict.
-        dict_to_avdict(&self.proxy.ptr.metadata, self.metadata, clear=True)
+        dict_to_avdict(&self.proxy.ptr.metadata, self.metadata, clear=True,
+                       encoding=self.encoding, errors=self.errors)
 
         cdef _Dictionary options = self.options.copy()
         self.proxy.err_check(lib.avformat_write_header(

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -61,7 +61,9 @@ cdef class Stream(object):
 
         self._codec_context = stream.codec
 
-        self.metadata = avdict_to_dict(stream.metadata)
+        self.metadata = avdict_to_dict(stream.metadata,
+                                       encoding=self._container.encoding,
+                                       errors=self._container.errors)
 
         # This is an input container!
         if self._container.ptr.iformat:
@@ -113,7 +115,8 @@ cdef class Stream(object):
         setattr(self.codec_context, name, value)
 
     cdef _finalize_for_output(self):
-        dict_to_avdict(&self._stream.metadata, self.metadata, clear=True)
+        dict_to_avdict(&self._stream.metadata, self.metadata, clear=True,
+                       encoding=self._container.encoding, errors=self._container.errors)
         if not self._stream.time_base.num:
             self._stream.time_base = self._codec_context.time_base
 

--- a/av/utils.pxd
+++ b/av/utils.pxd
@@ -9,8 +9,8 @@ cdef int err_check(int res=*, str filename=*) except -1
 
 
 
-cdef dict avdict_to_dict(lib.AVDictionary *input)
-cdef dict_to_avdict(lib.AVDictionary **dst, dict src, bint clear=*)
+cdef dict avdict_to_dict(lib.AVDictionary *input, str encoding=*, str errors=*)
+cdef dict_to_avdict(lib.AVDictionary **dst, dict src, bint clear=*, str encoding=*, str errors=*)
 
 
 


### PR DESCRIPTION
For writing, and for reading on Python 3, the default codec changes
from ASCII to UTF-8. In Python 2, the default behavior remains to not
perform decoding on reading, but this can be overridden by explicitly
specifying an encoding. This change applies to both container and
stream metadata.

fixes #59 