### PR TITLE
Fix SegFault resulting from incorrect FFMPEG structures deallocation

### DIFF
--- a/av/container/core.pxd
+++ b/av/container/core.pxd
@@ -31,6 +31,7 @@ cdef class ContainerProxy(object):
     cdef unsigned char *buffer
     cdef long pos
     cdef bint pos_is_valid
+    cdef bint is_opened
 
     cdef int err_check(self, int value) except -1
 

--- a/av/container/core.pyx
+++ b/av/container/core.pyx
@@ -128,7 +128,7 @@ cdef class ContainerProxy(object):
 
         # We used to take floats here and assume they were in seconds. This
         # was super confusing, so lets go in the complete opposite direction.
-        if not isinstance(offset, int):
+        if not isinstance(offset, (int, long)):
             raise TypeError('Container.seek only accepts integer offset.', type(offset))
         cdef int64_t c_offset = offset
 

--- a/include/libavformat/avformat.pxd
+++ b/include/libavformat/avformat.pxd
@@ -60,6 +60,8 @@ cdef extern from "libavformat/avformat.pyav.h" nogil:
 
     # http://ffmpeg.org/doxygen/trunk/structAVIOContext.html
     cdef struct AVIOContext:
+        unsigned char* buffer
+        int buffer_size
         int write_flag
         int direct
         int seekable

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -2,7 +2,10 @@ from __future__ import print_function
 
 from fractions import Fraction
 
-from common import *
+try:
+    from common import *
+except ImportError:
+    from .common import *
 
 from av.buffer import Buffer
 from av.packet import Packet
@@ -263,7 +266,7 @@ class TestCodecContext(TestCase):
 
         test_bad = False
 
-        with open(path, 'w') as f:
+        with open(path, 'wb') as f:
             for frame in iter_frames(container, audio_stream):
 
                 # We need to let the encoder retime.

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -144,7 +144,7 @@ class TestEncodeStreamSemantics(TestCase):
         self.assertIs(vpacket.stream, vstream)
         self.assertEqual(vpacket.stream_index, 0)
 
-        for i in xrange(10):
+        for i in range(10):
             aframe = AudioFrame('s16', 'stereo', samples=astream.frame_size)
             aframe.rate = 48000
             apackets = astream.encode(aframe)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,6 +1,9 @@
 from av.option import Option
 
-from common import *
+try:
+    from common import *
+except ImportError:
+    from .common import *
 
 
 class TestOptions(TestCase):

--- a/tests/test_random_input.py
+++ b/tests/test_random_input.py
@@ -1,0 +1,15 @@
+import io
+import random
+
+try:
+    from common import *
+except ImportError:
+    from .common import *
+
+
+class TestRandomInput(TestCase):
+    
+    def test_random_input(self):
+        random_data = ''.join(map(chr, [random.randint(0, 127) for _ in range(1024)])).encode('latin-1')
+        with self.assertRaises(av.AVError):
+            av.open(io.BytesIO(random_data))


### PR DESCRIPTION
[=] fix segfault resulting from incorrect FFMPEG structures deallocation
[=] fix some tests to be runnable under python3
[+] add test for correct (segfault free) opening of file with random data
[=] fix ContainerProxy.seek behaviour for integers more then 2**31 with 32bit CPython
