### PR TITLE
Enable reading Unicode metadata

### DIFF
--- a/av/utils.pyx
+++ b/av/utils.pyx
@@ -116,11 +116,14 @@ cdef dict avdict_to_dict(lib.AVDictionary *input):
 
     cdef lib.AVDictionaryEntry *element = NULL
     cdef dict output = {}
+    cdef bytes k, v
     while True:
         element = lib.av_dict_get(input, "", element, lib.AV_DICT_IGNORE_SUFFIX)
         if element == NULL:
             break
-        output[element.key] = element.value
+        k = element.key
+        v = element.value
+        output[k.decode()] = v.decode()
     return output
 
 


### PR DESCRIPTION
https://github.com/mikeboers/PyAV/issues/197

I'm new to Cython so the code is kludgy, but it can now handle both ASCII and UTF-8 metadata. It will bork for non-UTF-8 metadata.