### PR TITLE
Expose frame corruption check.

### DIFF
--- a/av/frame.pyx
+++ b/av/frame.pyx
@@ -119,3 +119,6 @@ cdef class Frame(object):
                 return avrational_to_faction(&self._time_base)
         def __set__(self, value):
             to_avrational(value, &self._time_base)
+
+    property is_corrupt:
+        def __get__(self): return bool(self.ptr.flags & lib.AV_FRAME_FLAG_CORRUPT)

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -45,6 +45,8 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
     cdef int AV_PKT_FLAG_KEY
     cdef int AV_PKT_FLAG_CORRUPT
 
+    cdef int AV_FRAME_FLAG_CORRUPT
+
     cdef int FF_COMPLIANCE_VERY_STRICT
     cdef int FF_COMPLIANCE_STRICT
     cdef int FF_COMPLIANCE_NORMAL
@@ -214,7 +216,6 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
         int channels # Number of audio channels
         int channel_layout # Audio channel_layout
 
-
         int64_t pts
         int64_t pkt_pts # Deprecated.
         int64_t pkt_dts # Deprecated.
@@ -224,6 +225,7 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
         uint8_t **base
         void *opaque
         AVDictionary *metadata
+        int flags
 
 
     cdef AVFrame* avcodec_alloc_frame()


### PR DESCRIPTION
`int AVFrame::flags` is a collection of `AV_FRAME_FLAGS`

Added property `is_corrupt` to class Frame that checks
if `AV_FRAME_FLAG_CORRUPT` is set which would then indicate that:

```
The frame data may be corrupted, e.g.
due to decoding errors.
```