### PR TITLE
fix segfault when stream is not recognized

### DIFF
--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -107,10 +107,7 @@ cdef class Stream(object):
         try:
             return getattr(self.codec_context, name)
         except AttributeError:
-            try:
-                return getattr(self.codec, name)
-            except AttributeError:
-                raise AttributeError(name)
+            return
 
     def __setattr__(self, name, value):
         setattr(self.codec_context, name, value)


### PR DESCRIPTION
I have a mpegts file which contains 3 streams. Video, Data and Audio. ffprobe is unable to identify codec for the audio. PyAV causes infinite loop and segfaults. This simple patch seem to fix the problem.