### PR TITLE
Decoding raw packets without streams using codecs that needs extradata

### DIFF
--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -1,6 +1,6 @@
 from cpython cimport PyWeakref_NewRef
 from libc.errno cimport EAGAIN
-from libc.stdint cimport uint8_t, int64_t, int32_t
+from libc.stdint cimport uint8_t, int64_t
 from libc.stdlib cimport malloc, realloc, free
 from libc.string cimport memcpy
 
@@ -332,9 +332,6 @@ cdef class CodecContext(object):
                 break
 
         return res
-
-    def info(self):
-        print('extradata_size', self.ptr.extradata_size)
 
     cdef _setup_encoded_packet(self, Packet packet):
         # The packet's timing was simply copied across from the source frame.

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -145,6 +145,10 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
         AVRational time_base
         int ticks_per_frame
 
+        int extradata_size
+        uint8_t *extradata
+        
+        int delay
 
         AVCodec *codec
 


### PR DESCRIPTION
For decoding raw packets without streams, some codecs need a few extradata (like Huffman tables).
In this commit, I provided two functions, one for extracting these data and the other for setting them when we want to decode without a stream.

An example usage:

```python
import av

container = av.open('somevideo.mp4')

# Find index of the video stream 
video_stream_index = 0
for index, stream in enumerate(container.streams):
    if isinstance(stream, av.video.stream.VideoStream):
        video_stream_index = index
        break

buffered_packets = []
count = 0
now = False
for packet in container.demux(streams=video_stream_index):
    count += 1
    # We only buffer some packets (here from 100 to 500)
    if count > 100:
        new_packet = av.packet.Packet(input=packet.to_bytes())
        # First packet need to be a keyframe
        if packet.is_keyframe or now:
            buffered_packets.append(new_packet)
            now = True

    if count > 500:
        break

codec_name = container.streams[video_stream_index].codec_context.name
codec_origin = container.streams[video_stream_index].codec_context
codec_new = av.codec.CodecContext.create(codec_name, 'r')


extradata = codec_origin.extradata
if not extradata is None:
    codec_new.extradata = extradata

for packet in buffered_packets:
    try:
        for frame in codec_new.decode(packet):
            frame.to_image().save('frame-%04d.jpg' % frame.index)
    except av.AVError as e:
        print(e)
```

