### PR TITLE
Frame: Refined corruption detection.

### DIFF
--- a/av/frame.pyx
+++ b/av/frame.pyx
@@ -121,4 +121,4 @@ cdef class Frame(object):
             to_avrational(value, &self._time_base)
 
     property is_corrupt:
-        def __get__(self): return bool(self.ptr.flags & lib.AV_FRAME_FLAG_CORRUPT)
+        def __get__(self): return self.ptr.decode_error_flags != 0 or bool(self.ptr.flags & lib.AV_FRAME_FLAG_CORRUPT)

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -246,6 +246,7 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
         void *opaque
         AVDictionary *metadata
         int flags
+        int decode_error_flags
 
 
     cdef AVFrame* avcodec_alloc_frame()


### PR DESCRIPTION
Found that previous code was incomplete and did not properly [detect frame corruption during decoding](http://lists.ffmpeg.org/pipermail/ffmpeg-user/2017-June/036315.html)

```
> i'm decoding video stream using ffmpeg, what i want to do is to check if
> the picture is broken when a frame is decoded by
> avcodec_decode_video2(). i call av_frame_get_decode_error_flags() on
> decoded frame to get the errflags, but it returned 0 all the time. am i
> calling the right function to get what i want? what's the right way to
> check integrity of a decoded picture?

You need to check

- return value of avcodec_decode_video2 (or avcodec_send_packet/receive_frame)
- if you have a frame, then check
      - frame->decode_error_flags (any nonzero value means error)
      - frame->flags & AV_FRAME_FLAG_CORRUPT (some codecs set this and not the decode_error_flags)

I am afraid not all codecs properly report all failed decodings, but
patches are welcome, if you find a decode error without signalling it in
at least one way of the above three...
```

[int AVFrame::decode_error_flags reference](https://ffmpeg.org/doxygen/2.7/structAVFrame.html#a3dd46fd353a405f6e9b91c11d9c5b736)