### PR TITLE
Add project metadata to PyPI.org webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ Have fun, [Read the Docs][docs], and good luck!
 [docs]: http://mikeboers.github.io/PyAV/
 [conda-forge]: https://conda-forge.github.io/
 [conda-install]: https://conda.io/docs/install/quick.html
-[pypi]: https://pypi.python.org/pypi/av
+[pypi]: https://pypi.org/project/av
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 license = BSD
-license_file = LICENSE.txt
 long_description = file: README.md
 long_description_content_type = text/markdown
 project_urls =

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,14 @@
+[metadata]
+license = BSD
+license_file = LICENSE.txt
+long_description = file: README.md
+long_description_content_type = text/markdown
+project_urls =
+    Bug Reports = https://github.com/mikeboers/PyAV/issues
+    Documentation = http://mikeboers.github.io/PyAV/
+    Feedstock = https://github.com/conda-forge/av-feedstock
+    Download = https://pypi.org/project/av
+
 [nosetests]
 verbosity = 2
 logging-clear-handlers = 1


### PR DESCRIPTION
Hi Mike (or anyone reading this),

since the new PyPI supports Markdown READMEs, I added the appropriate settings to `setup.cfg` so that the PyPI page actually displays something.

I also added some project links (that are displayed on the left-hand side of https://pypi.org/project/av/), currently there's only **Homepage** but I also added:

- **Bug Reports** with a link to the GitHub issue tracker
- **Documentation** with a link to the docs
- **Feedstock** with a link to the `av` conda-forge feedstock

I also added a `license` key to the metadata, as for now https://shields.io fails to extract the license from the classifiers. This means the license badge for `av`, which currently is:
![license-av](https://img.shields.io/pypi/l/av.svg)
should look like this once the PR is merged:
![license-ok](https://img.shields.io/badge/license-BSD-blue.svg)