### PR TITLE
Fix IndentationError(unexpected indent) in activate.sh

### DIFF
--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -42,10 +42,10 @@ if [[ "$TRAVIS" ]]; then
 else
 
     export PYAV_VENV_NAME="$(uname -s).$(uname -r).$("$PYAV_PYTHON" -c '
-    from __future__ import print_function
-    import sys
-    import platform
-    print("{}{}.{}".format(platform.python_implementation().lower(), *sys.version_info[:2]))
+from __future__ import print_function
+import sys
+import platform
+print("{}{}.{}".format(platform.python_implementation().lower(), *sys.version_info[:2]))
     ')"
     export PYAV_VENV="$PYAV_ROOT/venvs/$PYAV_VENV_NAME"
 


### PR DESCRIPTION
When do `bash scripts/build-deps`,the script will print below errors:
`+++ python -c '
    from __future__ import print_function
    import sys
    import platform
    print("{}{}.{}".format(platform.python_implementation().lower(), *sys.version_info[:2]))
    '
  File "<string>", line 2
    from __future__ import print_function
    ^
IndentationError: unexpected indent`

This PR is to fix this issue.
