### PR TITLE
fix for cython 0.28

### DIFF
--- a/av/enums.pyx
+++ b/av/enums.pyx
@@ -126,7 +126,7 @@ cdef class EnumItem(object):
 
     cdef readonly str name
     cdef readonly int value
-    cdef long _hash
+    cdef unsigned long _hash
 
     def __cinit__(self, sentinel_, name, value):
 


### PR DESCRIPTION
fixes #341 OverflowError: Python int too large to convert to C long