### PR TITLE
Add some docstrings for Frame base class

### DIFF
--- a/av/frame.pyx
+++ b/av/frame.pyx
@@ -9,8 +9,11 @@ from fractions import Fraction
 
 
 cdef class Frame(object):
+    """
+    Base class for audio and video frames.
 
-    """Frame Base Class"""
+    See also :class:`~av.audio.frame.AudioFrame` and :class:`~av.video.frame.VideoFrame`.
+    """
 
     def __cinit__(self, *args, **kwargs):
         with nogil:
@@ -89,14 +92,25 @@ cdef class Frame(object):
 
         self._time_base = dst
 
-
     property dts:
+        """
+        The decoding timestamp in :attr:`time_base` units for this frame.
+
+        :type: int
+        """
         def __get__(self):
             if self.ptr.pkt_dts == lib.AV_NOPTS_VALUE:
                 return None
             return self.ptr.pkt_dts
 
     property pts:
+        """
+        The presentation timestamp in :attr:`time_base` units for this frame.
+
+        This is the time at which the frame should be shown to the user.
+
+        :type: int
+        """
         def __get__(self):
             if self.ptr.pts == lib.AV_NOPTS_VALUE:
                 return None
@@ -108,6 +122,13 @@ cdef class Frame(object):
                 self.ptr.pts = value
 
     property time:
+        """
+        The presentation time in seconds for this frame.
+
+        This is the time at which the frame should be shown to the user.
+
+        :type: float
+        """
         def __get__(self):
             if self.ptr.pts == lib.AV_NOPTS_VALUE:
                 return None
@@ -115,6 +136,11 @@ cdef class Frame(object):
                 return float(self.ptr.pts) * self._time_base.num / self._time_base.den
 
     property time_base:
+        """
+        The unit of time (in fractional seconds) in which timestamps are expressed.
+
+        :type: fractions.Fraction
+        """
         def __get__(self):
             if self._time_base.num:
                 return avrational_to_faction(&self._time_base)
@@ -122,4 +148,9 @@ cdef class Frame(object):
             to_avrational(value, &self._time_base)
 
     property is_corrupt:
+        """
+        Is this frame corrupt?
+
+        :type: bool
+        """
         def __get__(self): return self.ptr.decode_error_flags != 0 or bool(self.ptr.flags & lib.AV_FRAME_FLAG_CORRUPT)


### PR DESCRIPTION
This PR adds docstrings for the Frame base class, notably about timestamps.

I couldn't figure out how to document `index` and `planes` which are defined in the .pxd file, any hints?