### PR TITLE
Fix travis and appveyor continuous integration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,15 +54,6 @@ environment:
       CONDA_PY: "36"
       CONDA_NPY: "112"
 
-    # older FFMPEG versions
-
-    - PYTHON: "C:\\Miniconda36-x64"
-      PYTHON_VERSION: "3.5"
-      FFMPEG_VERSION: "2.8.6"
-      PYTHON_ARCH: "64"
-      CONDA_PY: "35"
-      CONDA_NPY: "110"
-
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
 

--- a/av/container/core.pxd
+++ b/av/container/core.pxd
@@ -26,6 +26,7 @@ cdef class ContainerProxy(object):
     cdef object fread
     cdef object fwrite
     cdef object fseek
+    cdef object ftell
 
     # Custom IO for above.
     cdef lib.AVIOContext *iocontext

--- a/av/container/core.pyx
+++ b/av/container/core.pyx
@@ -77,6 +77,7 @@ cdef class ContainerProxy(object):
             self.fread = getattr(self.file, 'read', None)
             self.fwrite = getattr(self.file, 'write', None)
             self.fseek = getattr(self.file, 'seek', None)
+            self.ftell = getattr(self.file, 'tell', None)
 
             if self.writeable:
                 if self.fwrite is None:
@@ -98,10 +99,10 @@ cdef class ContainerProxy(object):
                 <void*>self, # User data.
                 pyio_read,
                 pyio_write,
-                pyio_seek 
+                pyio_seek
             )
 
-            if self.fseek is not None:
+            if self.fseek is not None and self.ftell is not None:
                 self.iocontext.seekable = lib.AVIO_SEEKABLE_NORMAL
             self.iocontext.max_packet_size = self.bufsize
             self.ptr.pb = self.iocontext

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -39,6 +39,9 @@ if [[ "$TRAVIS" ]]; then
     # Travis as a very self-contained environment. Lets just work in that.
     echo "We're on Travis, so not setting up another virtualenv."
 
+    if [[ "$TRAVIS_PYTHON_VERSION" = "2.7" || "$TRAVIS_PYTHON_VERSION" = "pypy" ]]; then
+        PYAV_PYTHON=python
+    fi
 else
 
     export PYAV_VENV_NAME="$(uname -s).$(uname -r).$("$PYAV_PYTHON" -c '

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,10 +1,25 @@
 # coding: utf8
 
+import os
+import sys
+import unittest
+
 from .common import *
+
+# On Windows, Python 3.0 - 3.5 have issues handling unicode filenames.
+# Starting with Python 3.6 the situation is saner thanks to PEP 529:
+#
+# https://www.python.org/dev/peps/pep-0529/
+
+broken_unicode = (
+    os.name == 'nt' and
+    sys.version_info >= (3, 0) and
+    sys.version_info < (3, 6))
 
 
 class TestContainers(TestCase):
 
+    @unittest.skipIf(broken_unicode, 'Unicode filename handling is broken')
     def test_unicode_filename(self):
 
         container = av.open(self.sandboxed(u'¢∞§¶•ªº.mov'), 'w')


### PR DESCRIPTION
The Python 2.7 builds are bombing:

ImportError: No module named 'setuptools'