### PR TITLE
Fix Codec.audio_rates and Codec.frame_rates

### DIFF
--- a/av/codec/codec.pxd
+++ b/av/codec/codec.pxd
@@ -1,15 +1,13 @@
-from libc.stdint cimport uint64_t
-
 cimport libav as lib
 
 
 cdef class Codec(object):
 
-    cdef lib.AVCodec *ptr
-    cdef lib.AVCodecDescriptor *desc
+    cdef const lib.AVCodec *ptr
+    cdef const lib.AVCodecDescriptor *desc
     cdef readonly bint is_encoder
 
     cdef _init(self, name=?)
 
 
-cdef Codec wrap_codec(lib.AVCodec *ptr)
+cdef Codec wrap_codec(const lib.AVCodec *ptr)

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,11 +1,28 @@
-from .common import *
+import unittest
+
+from av.audio.format import AudioFormat
 from av.codec import Codec, codecs_available
+from av.codec.codec import UnknownCodecError
 from av.video.format import VideoFormat
 
+from .common import TestCase
+
+# some older ffmpeg versions have no native opus encoder
+try:
+    opus_c = Codec('opus', 'w')
+    opus_encoder_missing = False
+except UnknownCodecError:
+    opus_encoder_missing = True
+
+
 class TestCodecs(TestCase):
+    def test_codec_bogus(self):
+        with self.assertRaises(UnknownCodecError):
+            Codec('bogus123')
+        with self.assertRaises(UnknownCodecError):
+            Codec('bogus123', 'w')
 
-    def test_codec_mpeg4(self):
-
+    def test_codec_mpeg4_decoder(self):
         c = Codec('mpeg4')
 
         self.assertEqual(c.name, 'mpeg4')
@@ -15,11 +32,19 @@ class TestCodecs(TestCase):
         self.assertTrue(c.is_decoder)
         self.assertFalse(c.is_encoder)
 
+        # audio
+        self.assertIsNone(c.audio_formats)
+        self.assertIsNone(c.audio_rates)
+
+        # video
         formats = c.video_formats
         self.assertTrue(formats)
         self.assertIsInstance(formats[0], VideoFormat)
         self.assertTrue(any(f.name == 'yuv420p' for f in formats))
 
+        self.assertIsNone(c.frame_rates)
+
+    def test_codec_mpeg4_encoder(self):
         c = Codec('mpeg4', 'w')
         self.assertEqual(c.name, 'mpeg4')
         self.assertEqual(c.long_name, 'MPEG-4 part 2')
@@ -27,6 +52,57 @@ class TestCodecs(TestCase):
         self.assertIn(c.id, (12, 13))
         self.assertTrue(c.is_encoder)
         self.assertFalse(c.is_decoder)
+
+        # audio
+        self.assertIsNone(c.audio_formats)
+        self.assertIsNone(c.audio_rates)
+
+        # video
+        formats = c.video_formats
+        self.assertTrue(formats)
+        self.assertIsInstance(formats[0], VideoFormat)
+        self.assertTrue(any(f.name == 'yuv420p' for f in formats))
+
+        self.assertIsNone(c.frame_rates)
+
+    def test_codec_opus_decoder(self):
+        c = Codec('opus')
+
+        self.assertEqual(c.name, 'opus')
+        self.assertEqual(c.long_name, 'Opus')
+        self.assertEqual(c.type, 'audio')
+        self.assertTrue(c.is_decoder)
+        self.assertFalse(c.is_encoder)
+
+        # audio
+        self.assertIsNone(c.audio_formats)
+        self.assertIsNone(c.audio_rates)
+
+        # video
+        self.assertIsNone(c.video_formats)
+        self.assertIsNone(c.frame_rates)
+
+    @unittest.skipIf(opus_encoder_missing, 'Opus encoder is not available')
+    def test_codec_opus_encoder(self):
+        c = Codec('opus', 'w')
+        self.assertIn(c.name, ('opus', 'libopus'))
+        self.assertIn(c.long_name, ('Opus', 'libopus Opus'))
+        self.assertEqual(c.type, 'audio')
+        self.assertTrue(c.is_encoder)
+        self.assertFalse(c.is_decoder)
+
+        # audio
+        formats = c.audio_formats
+        self.assertTrue(formats)
+        self.assertIsInstance(formats[0], AudioFormat)
+        self.assertTrue(any(f.name in ['flt', 'fltp'] for f in formats))
+
+        self.assertIsNotNone(c.audio_rates)
+        self.assertIn(48000, c.audio_rates)
+
+        # video
+        self.assertIsNone(c.video_formats)
+        self.assertIsNone(c.frame_rates)
 
     def test_codecs_available(self):
         self.assertTrue(codecs_available)


### PR DESCRIPTION
The properties returned a pointer cast to an int instead of the
actual supported rates.

I have added a test using Opus to test audio_rates.

I have not found *any* codecs which report frame_rates,
so that property is untested.