### PR TITLE
Close file descriptors in tests

### DIFF
--- a/tests/test_python_io.py
+++ b/tests/test_python_io.py
@@ -17,20 +17,20 @@ class TestPythonIO(TestCase):
 
     def test_reading(self):
 
-        fh = open(fate_suite('mpeg2/mpeg2_field_encoding.ts'), 'rb')
-        wrapped = MethodLogger(fh)
+        with open(fate_suite('mpeg2/mpeg2_field_encoding.ts'), 'rb') as fh:
+            wrapped = MethodLogger(fh)
 
-        container = av.open(wrapped)
+            container = av.open(wrapped)
 
-        self.assertEqual(container.format.name, 'mpegts')
-        self.assertEqual(container.format.long_name, "MPEG-TS (MPEG-2 Transport Stream)")
-        self.assertEqual(len(container.streams), 1)
-        self.assertEqual(container.size, 800000)
-        self.assertEqual(container.metadata, {})
+            self.assertEqual(container.format.name, 'mpegts')
+            self.assertEqual(container.format.long_name, "MPEG-TS (MPEG-2 Transport Stream)")
+            self.assertEqual(len(container.streams), 1)
+            self.assertEqual(container.size, 800000)
+            self.assertEqual(container.metadata, {})
 
-        # Make sure it did actually call "read".
-        reads = wrapped._filter('read')
-        self.assertTrue(reads)
+            # Make sure it did actually call "read".
+            reads = wrapped._filter('read')
+            self.assertTrue(reads)
 
     def test_basic_errors(self):
         self.assertRaises(Exception, av.open, None)
@@ -39,20 +39,20 @@ class TestPythonIO(TestCase):
     def test_writing(self):
 
         path = self.sandboxed('writing.mov')
-        fh = open(path, 'wb')
-        wrapped = MethodLogger(fh)
+        with open(path, 'wb') as fh:
+            wrapped = MethodLogger(fh)
 
-        output = av.open(wrapped, 'w', 'mov')
-        write_rgb_rotate(output)
-        output.close()
-        fh.close()
+            output = av.open(wrapped, 'w', 'mov')
+            write_rgb_rotate(output)
+            output.close()
+            fh.close()
 
-        # Make sure it did actually write.
-        writes = wrapped._filter('write')
-        self.assertTrue(writes)
+            # Make sure it did actually write.
+            writes = wrapped._filter('write')
+            self.assertTrue(writes)
 
-        # Standard assertions.
-        assert_rgb_rotate(self, av.open(path))
+            # Standard assertions.
+            assert_rgb_rotate(self, av.open(path))
 
     def test_buffer_read_write(self):
 


### PR DESCRIPTION
This fixes a warning due to file descriptors not being closed in two
Python I/O tests.