### PR TITLE
Stop using deprecated pkt_pts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,21 +111,6 @@ matrix:
           env: LIBRARY=ffmpeg-4.0
           os: linux
 
-        # Older FFmpeg.
-        # These are set to be deprecated in the next major release.
-        - python: "3.6"
-          env: LIBRARY=ffmpeg-3.1
-          os: linux
-        - python: "3.6"
-          env: LIBRARY=ffmpeg-3.0
-          os: linux
-        - python: "2.7"
-          env: LIBRARY=ffmpeg-3.1
-          os: linux
-        - python: "2.7"
-          env: LIBRARY=ffmpeg-3.0
-          os: linux
-
     allow_failures:
 
         - python: "pypy"

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,9 @@ We are operating with `semantic versioning <http://semver.org>`_.
 v6.0.0.dev0
 -----------
 
-Nothing yet!
+Major:
+
+- Dropped support for FFmpeg < 3.2.
 
 
 v0.x.y

--- a/av/audio/fifo.pyx
+++ b/av/audio/fifo.pyx
@@ -81,9 +81,9 @@ cdef class AudioFifo:
             raise ValueError('Frame does not match AudioFifo parameters.')
 
         # Assert that the PTS are what we expect.
-        cdef uint64_t expected_pts
+        cdef int64_t expected_pts
         if self.pts_per_sample and frame.ptr.pts != lib.AV_NOPTS_VALUE:
-            expected_pts = <uint64_t>(self.pts_per_sample * self.samples_written)
+            expected_pts = <int64_t>(self.pts_per_sample * self.samples_written)
             if frame.ptr.pts != expected_pts:
                 raise ValueError('Frame.pts (%d) != expected (%d); fix or set to None.' % (frame.ptr.pts, expected_pts))
 

--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -445,14 +445,7 @@ cdef class CodecContext(object):
 
     cdef _setup_decoded_frame(self, Frame frame, Packet packet):
 
-        # In FFMpeg <= 3.0, and all LibAV we know of, the frame's pts may be
-        # unset at this stage, and the PTS from a packet is the correct one while
-        # decoding, and it is copied to pkt_pts during creation of a frame.
-        # TODO: Look into deprecation of pkt_pts in FFmpeg > 3.0
-        if frame.ptr.pts == lib.AV_NOPTS_VALUE:
-            frame.ptr.pts = frame.ptr.pkt_pts
-
-        # Propigate our manual times.
+        # Propagate our manual times.
         # While decoding, frame times are in stream time_base, which PyAV
         # is carrying around.
         # TODO: Somehow get this from the stream so we can not pass the

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,7 @@ See the `Conda quick install <https://conda.io/docs/install/quick.html>`_ docs t
 Dependencies
 ------------
 
-PyAV depends upon several libraries from FFmpeg (version ``3.0`` or higher):
+PyAV depends upon several libraries from FFmpeg (version ``3.2`` or higher):
 
 - ``libavformat``
 - ``libavcodec``

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -242,8 +242,7 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
         int channel_layout # Audio channel_layout
 
         int64_t pts
-        int64_t pkt_pts # Deprecated.
-        int64_t pkt_dts # Deprecated.
+        int64_t pkt_dts
 
         int pkt_size
 
@@ -369,7 +368,6 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
         AVCodec *codec
     )
 
-    cdef int64_t av_frame_get_best_effort_timestamp(AVFrame *frame)
     cdef void avcodec_flush_buffers(AVCodecContext *ctx)
 
      # TODO: avcodec_default_get_buffer is deprecated for avcodec_default_get_buffer2 in newer versions of FFmpeg

--- a/include/libavcodec/avcodec.pyav.h
+++ b/include/libavcodec/avcodec.pyav.h
@@ -1,17 +1,6 @@
 #include "libavcodec/avcodec.h"
 
 
-#if !PYAV_HAVE_AV_FRAME_GET_BEST_EFFORT_TIMESTAMP
-
-    int64_t av_frame_get_best_effort_timestamp(const AVFrame *frame)
-    {
-        // TODO: do this right.
-        return frame->pkt_pts;
-    }
-
-#endif
-
-
 #if PYAV_HAVE_FFMPEG
 
     #define AVPixelFormat PixelFormat

--- a/setup.py
+++ b/setup.py
@@ -548,7 +548,6 @@ class ReflectCommand(Command):
 
             # This we actually care about:
             'av_calloc',
-            'av_frame_get_best_effort_timestamp',
             'avformat_alloc_output_context2',
             'avformat_close_input',
             'avcodec_send_packet',


### PR DESCRIPTION
Only use frame.pts, frame.pkt_pts is obsolete.

Also stop detecting the presence of av_frame_get_best_effort_timestamp,
it's guaranteed to be present now that we require ffmpeg >= 3.0. Not
that we use it anyway..