### PR TITLE
Reduce const warnings

### DIFF
--- a/av/audio/codeccontext.pyx
+++ b/av/audio/codeccontext.pyx
@@ -11,7 +11,7 @@ from av.utils cimport err_check
 cdef class AudioCodecContext(CodecContext):
 
 
-    cdef _init(self, lib.AVCodecContext *ptr, lib.AVCodec *codec):
+    cdef _init(self, lib.AVCodecContext *ptr, const lib.AVCodec *codec):
         CodecContext._init(self, ptr, codec)
 
         # Sometimes there isn't a layout set, but there are a number of

--- a/av/codec/context.pxd
+++ b/av/codec/context.pxd
@@ -29,7 +29,7 @@ cdef class CodecContext(object):
     # To hold a reference to passed extradata.
     cdef ByteSource extradata_source
 
-    cdef _init(self, lib.AVCodecContext *ptr, lib.AVCodec *codec)
+    cdef _init(self, lib.AVCodecContext *ptr, const lib.AVCodec *codec)
 
     cdef readonly Codec codec
 
@@ -71,4 +71,4 @@ cdef class CodecContext(object):
     cdef Frame _alloc_next_frame(self)
 
 
-cdef CodecContext wrap_codec_context(lib.AVCodecContext*, lib.AVCodec*, ContainerProxy)
+cdef CodecContext wrap_codec_context(lib.AVCodecContext*, const lib.AVCodec*, ContainerProxy)

--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -18,7 +18,7 @@ from av.utils cimport err_check, avdict_to_dict, avrational_to_fraction, to_avra
 cdef object _cinit_sentinel = object()
 
 
-cdef CodecContext wrap_codec_context(lib.AVCodecContext *c_ctx, lib.AVCodec *c_codec, ContainerProxy container):
+cdef CodecContext wrap_codec_context(lib.AVCodecContext *c_ctx, const lib.AVCodec *c_codec, ContainerProxy container):
     """Build an av.CodecContext for an existing AVCodecContext."""
 
     cdef CodecContext py_ctx
@@ -78,7 +78,7 @@ cdef class CodecContext(object):
         self.stream_index = -1 # This is set by the container immediately.
 
 
-    cdef _init(self, lib.AVCodecContext *ptr, lib.AVCodec *codec):
+    cdef _init(self, lib.AVCodecContext *ptr, const lib.AVCodec *codec):
 
         self.ptr = ptr
         if self.ptr.codec and codec and self.ptr.codec != codec:

--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -40,7 +40,7 @@ cdef class OutputContainer(Container):
         if (codec_name is None and template is None) or (codec_name is not None and template is not None):
             raise ValueError('needs one of codec_name or template')
 
-        cdef lib.AVCodec *codec
+        cdef const lib.AVCodec *codec
         cdef Codec codec_obj
 
         if codec_name is not None:

--- a/av/data/stream.pyx
+++ b/av/data/stream.pyx
@@ -29,7 +29,7 @@ cdef class DataStream(Stream):
 
     property name:
         def __get__(self):
-            desc = lib.avcodec_descriptor_get(self._codec_context.codec_id)
+            cdef const lib.AVCodecDescriptor *desc = lib.avcodec_descriptor_get(self._codec_context.codec_id)
             if desc == NULL:
                 return None
             return desc.name

--- a/av/filter/filter.pyx
+++ b/av/filter/filter.pyx
@@ -90,7 +90,7 @@ cdef class Filter(object):
 
 
 filters_available = set()
-cdef lib.AVFilter *ptr = lib.avfilter_next(NULL)
+cdef const lib.AVFilter *ptr = lib.avfilter_next(NULL)
 while ptr:
     filters_available.add(ptr.name)
     ptr = lib.avfilter_next(ptr)

--- a/av/stream.pxd
+++ b/av/stream.pxd
@@ -19,7 +19,7 @@ cdef class Stream(object):
 
     # CodecContext attributes.
     cdef lib.AVCodecContext *_codec_context
-    cdef lib.AVCodec *_codec
+    cdef const lib.AVCodec *_codec
     cdef lib.AVDictionary *_codec_options
 
     cdef readonly CodecContext codec_context

--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -19,7 +19,7 @@ cdef class VideoCodecContext(CodecContext):
         self.last_w = 0
         self.last_h = 0
 
-    cdef _init(self, lib.AVCodecContext *ptr, lib.AVCodec *codec):
+    cdef _init(self, lib.AVCodecContext *ptr, const lib.AVCodec *codec):
         CodecContext._init(self, ptr, codec) # TODO: Can this be `super`?
         self._build_format()
         self.encoded_frame_count = 0

--- a/av/video/format.pxd
+++ b/av/video/format.pxd
@@ -4,7 +4,7 @@ cimport libav as lib
 cdef class VideoFormat(object):
 
     cdef lib.AVPixelFormat pix_fmt
-    cdef lib.AVPixFmtDescriptor *ptr
+    cdef const lib.AVPixFmtDescriptor *ptr
     cdef readonly unsigned int width, height
 
     cdef readonly tuple components
@@ -19,7 +19,7 @@ cdef class VideoFormatComponent(object):
 
     cdef VideoFormat format
     cdef readonly unsigned int index
-    cdef lib.AVComponentDescriptor *ptr
+    cdef const lib.AVComponentDescriptor *ptr
 
 
 cdef VideoFormat get_video_format(lib.AVPixelFormat c_format, unsigned int width, unsigned int height)

--- a/av/video/format.pyx
+++ b/av/video/format.pyx
@@ -170,7 +170,7 @@ cdef class VideoFormatComponent(object):
 
 
 names = set()
-cdef lib.AVPixFmtDescriptor *desc = NULL
+cdef const lib.AVPixFmtDescriptor *desc = NULL
 while True:
     desc = lib.av_pix_fmt_desc_next(desc)
     if not desc:


### PR DESCRIPTION
AVCodec pointers should always be passed as `const AVCodec*`.

This also fixes a few other missing const qualifiers.

The remaining const warnings are trickier as they are mostly a product of how Cython generates its code.