### PR TITLE
Defer wrapping output stream into Python object

### DIFF
--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -72,10 +72,6 @@ cdef class OutputContainer(Container):
         lib.avcodec_get_context_defaults3(stream.codec, codec)
         stream.codec.codec = codec # Still have to manually set this though...
 
-        # Construct the user-land stream so we have access to CodecContext.
-        cdef Stream py_stream = wrap_stream(self, stream)
-        self.streams.add_stream(py_stream)
-
         # Copy from the template.
         if template is not None:
             lib.avcodec_copy_context(codec_context, template._codec_context)
@@ -110,6 +106,10 @@ cdef class OutputContainer(Container):
         # Some formats want stream headers to be separate
         if self.proxy.ptr.oformat.flags & lib.AVFMT_GLOBALHEADER:
             codec_context.flags |= lib.AV_CODEC_FLAG_GLOBAL_HEADER
+
+        # Construct the user-land stream
+        cdef Stream py_stream = wrap_stream(self, stream)
+        self.streams.add_stream(py_stream)
 
         if options:
             py_stream.options.update(options)

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -122,8 +122,32 @@ class TestBasicAudioEncoding(TestCase):
 
 class TestEncodeStreamSemantics(TestCase):
 
-    def test_stream_index(self):
+    def test_audio_default_options(self):
+        output = av.open(self.sandboxed('output.mov'), 'w')
 
+        stream = output.add_stream('mp2')
+        self.assertEqual(stream.bit_rate, 128000)
+        self.assertEqual(stream.format.name, 's16')
+        self.assertEqual(stream.rate, 48000)
+        self.assertEqual(stream.ticks_per_frame, 1)
+        self.assertEqual(stream.time_base, None)
+
+    def test_video_default_options(self):
+        output = av.open(self.sandboxed('output.mov'), 'w')
+
+        stream = output.add_stream('mpeg4')
+        self.assertEqual(stream.bit_rate, 1024000)
+        self.assertEqual(stream.format.height, 480)
+        self.assertEqual(stream.format.name, 'yuv420p')
+        self.assertEqual(stream.format.width, 640)
+        self.assertEqual(stream.height, 480)
+        self.assertEqual(stream.pix_fmt, 'yuv420p')
+        self.assertEqual(stream.rate, Fraction(24, 1))
+        self.assertEqual(stream.ticks_per_frame, 1)
+        self.assertEqual(stream.time_base, None)
+        self.assertEqual(stream.width, 640)
+
+    def test_stream_index(self):
         output = av.open(self.sandboxed('output.mov'), 'w')
 
         vstream = output.add_stream('mpeg4', 24)


### PR DESCRIPTION
OutputContainer.add_stream() nicely initialises some default options
both for audio and video streams. Unfortunately, we wrap the low-level
AVCodecContext and AVStream into Python objects before we finish
initialising them.

For video streams this results in the crucial "pix_fmt" being cleared
inside VideoCodecContext._init, which leads to a crash during encoding
if the user does not set "pix_fmt" (again) themselves:

    Assertion desc failed at libswscale/swscale_internal.h:674

With this PR we finish the CodecContext initialization *before* we start
wrapping the stream into a Python object.

As a result of this fix, all video encoding examples can be simplified
to remove this:

   stream.pix_fmt = 'yuv420p'