### PR TITLE
Stop messing with packet dts and pts

### DIFF
--- a/av/container/input.pyx
+++ b/av/container/input.pyx
@@ -131,8 +131,6 @@ cdef class InputContainer(Container):
                     # TODO: find better way to handle this
                     if packet.struct.stream_index < len(self.streams):
                         packet._stream = self.streams[packet.struct.stream_index]
-                        # Keep track of this so that remuxing is easier.
-                        packet._time_base = packet._stream._stream.time_base
                         yield packet
 
             # Flush!

--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -213,7 +213,6 @@ cdef class OutputContainer(Container):
         if packet.struct.stream_index < 0 or packet.struct.stream_index >= self.proxy.ptr.nb_streams:
             raise ValueError('Bad Packet stream_index.')
         cdef lib.AVStream *stream = self.proxy.ptr.streams[packet.struct.stream_index]
-        packet._rebase_time(stream.time_base)
 
         # Make another reference to the packet, as av_interleaved_write_frame
         # takes ownership of it.

--- a/av/packet.pxd
+++ b/av/packet.pxd
@@ -11,10 +11,6 @@ cdef class Packet(Buffer):
 
     cdef Stream _stream
 
-    # We track our own time.
-    cdef lib.AVRational _time_base
-    cdef _rebase_time(self, lib.AVRational)
-
     # Hold onto the original reference.
     cdef ByteSource source
     cdef size_t _buffer_size(self)

--- a/examples/decode.py
+++ b/examples/decode.py
@@ -94,7 +94,7 @@ frame_count = 0
 for i, packet in enumerate(container.demux(streams)):
 
     print('%02d %r' % (i, packet))
-    print('\ttime_base: %s' % packet.time_base)
+    print('\ttime_base: %s' % packet.stream.time_base)
     print('\tduration: %s' % format_time(packet.duration, packet.stream.time_base))
     print('\tpts: %s' % format_time(packet.pts, packet.stream.time_base))
     print('\tdts: %s' % format_time(packet.dts, packet.stream.time_base))

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -46,6 +46,5 @@ class TestDecode(TestCase):
 
         for packet in container.demux(stream):
             for frame in packet.decode():
-                self.assertEqual(packet.time_base, frame.time_base)
                 self.assertEqual(stream.time_base, frame.time_base)
                 return


### PR DESCRIPTION
A packet's timebase is that of the stream it belongs to. Storing the
timebase and manipulating it ourselves leads to headaches.

For instance when encoding video, the "flush" packets carry a valid dts
and pts but their timebase doesn't get set, causing _rebase_time to
destroy these timestamps. This leads to an exception upon flushing the
output stream.