### PR TITLE
Expose AVFrame.pict_type

### DIFF
--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -254,6 +254,14 @@ cdef class VideoFrame(Frame):
         """Is this frame an interlaced or progressive?"""
         def __get__(self): return self.ptr.interlaced_frame
 
+    @property
+    def pict_type(self):
+        return self.ptr.pict_type
+
+    @pict_type.setter
+    def pict_type(self, value):
+        self.ptr.pict_type = value
+
     def to_rgb(self, **kwargs):
         """Get an RGB version of this frame.
 

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -229,6 +229,7 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
 
         int format # Should be AVPixelFormat or AVSampleFormat
         int key_frame # 0 or 1.
+        AVPictureType pict_type
 
         int interlaced_frame # 0 or 1.
 

--- a/include/libavutil/avutil.pxd
+++ b/include/libavutil/avutil.pxd
@@ -13,6 +13,16 @@ cdef extern from "libavutil/avutil.pyav.h" nogil:
     cdef char* avutil_configuration()
     cdef char* avutil_license()
 
+    cdef enum AVPictureType:
+        AV_PICTURE_TYPE_NONE
+        AV_PICTURE_TYPE_I
+        AV_PICTURE_TYPE_P
+        AV_PICTURE_TYPE_B
+        AV_PICTURE_TYPE_S
+        AV_PICTURE_TYPE_SI
+        AV_PICTURE_TYPE_SP
+        AV_PICTURE_TYPE_BI
+
     cdef enum AVPixelFormat:
         AV_PIX_FMT_NONE
         AV_PIX_FMT_YUV420P


### PR DESCRIPTION
This makes it possible to force an encoder to generate full intra
frames, for instance to recover from picture loss in realtime
communications.

NOTE: I would appreciate guidance as to how the enum values should be exposed