### PR TITLE
Rename Buffer.update_buffer to Buffer.update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ v0.5.3
 
 - Deprecate ``AudioFrame.to_nd_array()`` and ``VideoFrame.to_nd_array()`` in
   favour of ``.to_ndarray()``.
+- Deprecate ``Packet.update_buffer()`` in favour of ``Packet.update()``.
+- Deprecate ``Plane.update_buffer()`` in favour of ``Plane.update()``.
 
 v0.5.2
 ------

--- a/av/buffer.pyx
+++ b/av/buffer.pyx
@@ -3,6 +3,7 @@ from libc.string cimport memcpy
 from cpython cimport PyBuffer_FillInfo, PyBUF_WRITABLE
 
 from av.bytesource cimport ByteSource, bytesource
+from av.deprecation import renamed_attr
 
 
 cdef class _Buffer(object):
@@ -58,7 +59,7 @@ cdef class Buffer(_Buffer):
     def to_bytes(self):
         return <bytes>(<char*>self._buffer_ptr())[:self._buffer_size()]
 
-    def update_buffer(self, input):
+    def update(self, input):
         """Replace the data in this object with the given buffer."""
         if not self._buffer_writable():
             raise ValueError('buffer is not writable')
@@ -67,3 +68,5 @@ cdef class Buffer(_Buffer):
         if source.length != size:
             raise ValueError('got %d bytes; need %d bytes' % (len(input), size))
         memcpy(self._buffer_ptr(), source.ptr, size)
+
+    update_buffer = renamed_attr('update')

--- a/av/packet.pyx
+++ b/av/packet.pyx
@@ -35,7 +35,7 @@ cdef class Packet(Buffer):
             err_check(lib.av_new_packet(&self.struct, size))
 
         if source is not None:
-            self.update_buffer(source)
+            self.update(source)
             # TODO: Hold onto the source, and copy its pointer
             # instead of its data.
             #self.source = source

--- a/av/plane.pyx
+++ b/av/plane.pyx
@@ -1,3 +1,5 @@
+from av.deprecation import renamed_attr
+
 
 cdef class Plane(Buffer):
 
@@ -23,18 +25,4 @@ cdef class Plane(Buffer):
     cdef void*  _buffer_ptr(self):
         return self.frame.ptr.extended_data[self.index]
 
-    def update(self, input):
-        """Replace the data in this plane with the given string.
-
-        Deprecated; use :meth:`Plane.update_buffer` instead.
-
-        """
-        self.update_buffer(input)
-
-    def update_from_string(self, input):
-        """Replace the data in this plane with the given string.
-
-        Deprecated; use :meth:`Plane.update_buffer` instead.
-
-        """
-        self.update_buffer(input)
+    update_from_string = renamed_attr('update')

--- a/examples/gen_rgb_rotate.py
+++ b/examples/gen_rgb_rotate.py
@@ -21,7 +21,7 @@ stream.width = width
 stream.height = height
 stream.pix_fmt = "yuv420p"
 
-for frame_i in xrange(duration):
+for frame_i in range(duration):
 
     frame = VideoFrame(width, height, 'rgb24')
     image = Image.new('RGB', (width, height), (
@@ -29,7 +29,7 @@ for frame_i in xrange(duration):
         int(255 * (0.5 + 0.5 * math.sin(frame_i / duration * 2 * math.pi + 2 / 3 * math.pi))),
         int(255 * (0.5 + 0.5 * math.sin(frame_i / duration * 2 * math.pi + 4 / 3 * math.pi))),
     ))
-    frame.planes[0].update_from_string(image.tostring())
+    frame.planes[0].update(image.tobytes())
 
     packet = stream.encode(frame)
     if packet:

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -33,7 +33,7 @@ def write_rgb_rotate(output):
             int(255 * (0.5 + 0.5 * math.sin(frame_i / DURATION * 2 * math.pi + 2 / 3 * math.pi))),
             int(255 * (0.5 + 0.5 * math.sin(frame_i / DURATION * 2 * math.pi + 4 / 3 * math.pi))),
         ))
-        frame.planes[0].update_from_string(image.tobytes())
+        frame.planes[0].update(image.tobytes())
 
         for packet in stream.encode(frame):
             output.mux(packet)

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -63,7 +63,7 @@ class TestVideoFrameBuffers(TestCase):
         except NameError:
             raise SkipTest()
         frame = VideoFrame(640, 480, 'rgb24')
-        frame.planes[0].update_from_string('01234' + ('x' * (640 * 480 * 3 - 5)))
+        frame.planes[0].update(b'01234' + (b'x' * (640 * 480 * 3 - 5)))
         buf = buffer(frame.planes[0])
         self.assertEqual(buf[1], b'1')
         self.assertEqual(buf[:7], b'01234xx')
@@ -74,7 +74,7 @@ class TestVideoFrameBuffers(TestCase):
         except NameError:
             raise SkipTest()
         frame = VideoFrame(640, 480, 'rgb24')
-        frame.planes[0].update_from_string('01234' + ('x' * (640 * 480 * 3 - 5)))
+        frame.planes[0].update(b'01234' + (b'x' * (640 * 480 * 3 - 5)))
         mem = memoryview(frame.planes[0])
         self.assertEqual(mem.ndim, 1)
         self.assertEqual(mem.shape, (640 * 480 * 3, ))
@@ -97,7 +97,7 @@ class TestVideoFrameTransforms(TestCase):
         if not Image:
             raise SkipTest()
         frame = VideoFrame(self.width, self.height, 'rgb24')
-        frame.planes[0].update_from_string(self.image.tobytes())
+        frame.planes[0].update(self.image.tobytes())
         img = frame.to_image()
         img.save(self.sandboxed('roundtrip-low.jpg'))
         self.assertImagesAlmostEqual(self.image, img)


### PR DESCRIPTION
We provide the following backwards compatibility aliases

- Packet.update_buffer
- Plane.update_buffer and Plane.update_from_string