### PR TITLE
Fix AudioFrame docstrings

### DIFF
--- a/av/audio/codeccontext.pyx
+++ b/av/audio/codeccontext.pyx
@@ -142,7 +142,7 @@ cdef class AudioCodecContext(CodecContext):
         """
         The audio channel layout.
 
-        :type: ~av.audio.layout.AudioLayout
+        :type: AudioLayout
         """
         def __get__(self):
             return get_audio_layout(self.ptr.channels, self.ptr.channel_layout)
@@ -155,7 +155,7 @@ cdef class AudioCodecContext(CodecContext):
         """
         The audio sample format.
 
-        :type: ~av.audio.format.AudioFormat
+        :type: AudioFormat
         """
         def __get__(self):
             return get_audio_format(self.ptr.sample_fmt)

--- a/av/audio/frame.pxd
+++ b/av/audio/frame.pxd
@@ -21,14 +21,14 @@ cdef class AudioFrame(Frame):
     """
     The audio channel layout.
 
-    :type: ~av.audio.layout.AudioLayout
+    :type: AudioLayout
     """
 
     cdef readonly AudioFormat format
     """
     The audio sample format.
 
-    :type: ~av.audio.format.AudioFormat
+    :type: AudioFormat
     """
 
     cdef _init(self, lib.AVSampleFormat format, uint64_t layout, unsigned int nb_samples, bint align)

--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -131,8 +131,8 @@ cdef class AudioFrame(Frame):
             self.ptr.sample_rate = value
 
     def to_ndarray(self, **kwargs):
-        """Get a numpy array of this frame.
-        Any ``**kwargs`` are passed to :meth:`AudioFrame.reformat`.
+        """
+        Get a numpy array of this frame.
         """
 
         import numpy as np


### PR DESCRIPTION
Fix docstrings for `format` and `layout` so they link correctly.

Remove erroneous comment about `to_ndarray` kwargs.