### PR TITLE
Always use send / recv mechanism

### DIFF
--- a/av/audio/codeccontext.pyx
+++ b/av/audio/codeccontext.pyx
@@ -58,23 +58,6 @@ cdef class AudioCodecContext(CodecContext):
     cdef Frame _alloc_next_frame(self):
         return alloc_audio_frame()
 
-    cdef _decode(self, lib.AVPacket *packet, int *data_consumed):
-
-        if not self.next_frame:
-            self.next_frame = alloc_audio_frame()
-
-        cdef int completed_frame = 0
-        data_consumed[0] = err_check(lib.avcodec_decode_audio4(self.ptr, self.next_frame.ptr, &completed_frame, packet))
-        if not completed_frame:
-            return
-
-        cdef AudioFrame frame = self.next_frame
-        self.next_frame = None
-
-        frame._init_user_attributes()
-
-        return frame
-
     cdef _setup_decoded_frame(self, Frame frame, Packet packet):
         CodecContext._setup_decoded_frame(self, frame, packet)
         cdef AudioFrame aframe = frame

--- a/av/audio/codeccontext.pyx
+++ b/av/audio/codeccontext.pyx
@@ -55,27 +55,6 @@ cdef class AudioCodecContext(CodecContext):
 
         return frames
 
-    cdef _encode(self, Frame frame):
-        """Encodes a frame of audio, returns a packet if one is ready.
-        The output packet does not necessarily contain data for the most recent frame,
-        as encoders can delay, split, and combine input frames internally as needed.
-        If called with with no args it will flush out the encoder and return the buffered
-        packets until there are none left, at which it will return None.
-        """
-
-        cdef Packet packet = Packet()
-        cdef int got_packet = 0
-
-        err_check(lib.avcodec_encode_audio2(
-            self.ptr,
-            &packet.struct,
-            frame.ptr if frame is not None else NULL,
-            &got_packet,
-        ))
-
-        if got_packet:
-            return packet
-
     cdef Frame _alloc_next_frame(self):
         return alloc_audio_frame()
 

--- a/av/codec/context.pxd
+++ b/av/codec/context.pxd
@@ -43,7 +43,7 @@ cdef class CodecContext(object):
 
     # Wraps both versions of the transcode API, returning lists.
     cpdef encode(self, Frame frame=?)
-    cpdef decode(self, Packet packet=?, unsigned int count=?, bint prefer_send_recv=?)
+    cpdef decode(self, Packet packet=?)
 
     # Used by both transcode APIs to setup user-land objects.
     # TODO: Remove the `Packet` from `_setup_decoded_frame` (because flushing
@@ -51,9 +51,6 @@ cdef class CodecContext(object):
     cdef _prepare_frames_for_encode(self, Frame frame)
     cdef _setup_encoded_packet(self, Packet)
     cdef _setup_decoded_frame(self, Frame, Packet)
-
-    # Implemented by children for the encode/decode API.
-    cdef _decode(self, lib.AVPacket *packet, int *data_consumed)
 
     # Implemented by base for the generic send/recv API.
     # Note that the user cannot send without recieving. This is because

--- a/av/codec/context.pxd
+++ b/av/codec/context.pxd
@@ -42,7 +42,7 @@ cdef class CodecContext(object):
     cdef _set_default_time_base(self)
 
     # Wraps both versions of the transcode API, returning lists.
-    cpdef encode(self, Frame frame=?, unsigned int count=?, bint prefer_send_recv=?)
+    cpdef encode(self, Frame frame=?)
     cpdef decode(self, Packet packet=?, unsigned int count=?, bint prefer_send_recv=?)
 
     # Used by both transcode APIs to setup user-land objects.
@@ -53,7 +53,6 @@ cdef class CodecContext(object):
     cdef _setup_decoded_frame(self, Frame, Packet)
 
     # Implemented by children for the encode/decode API.
-    cdef _encode(self, Frame frame)
     cdef _decode(self, lib.AVPacket *packet, int *data_consumed)
 
     # Implemented by base for the generic send/recv API.

--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -85,9 +85,6 @@ cdef class CodecContext(object):
             raise RuntimeError('Wrapping CodecContext with mismatched codec.')
         self.codec = wrap_codec(codec if codec != NULL else self.ptr.codec)
 
-        # Signal that we want to reference count.
-        self.ptr.refcounted_frames = 1
-
         # Set reasonable threading defaults.
         # count == 0 -> use as many threads as there are CPUs.
         # type == 2 -> thread within a frame. This does not change the API.

--- a/av/packet.pyx
+++ b/av/packet.pyx
@@ -101,15 +101,15 @@ cdef class Packet(Buffer):
 
         self._time_base = dst
 
-    def decode(self, count=0):
+    def decode(self):
         """Decode the data in this packet into a list of Frames."""
-        return self._stream.decode(self, count)
+        return self._stream.decode(self)
 
     def decode_one(self):
         """Decode the first frame from this packet.
 
         Returns ``None`` if there is no frame."""
-        res = self._stream.decode(self, count=1)
+        res = self._stream.decode(self)
         return res[0] if res else None
 
     property stream_index:

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -124,8 +124,8 @@ cdef class Stream(object):
             packet.struct.stream_index = self._stream.index
         return packets
 
-    def decode(self, packet=None, count=0):
-        return self.codec_context.decode(packet, count)
+    def decode(self, packet=None):
+        return self.codec_context.decode(packet)
 
     def seek(self, offset, whence='time', backward=True, any_frame=False):
         """seek(offset, whence='time', backward=True, any_frame=False)

--- a/av/subtitles/codeccontext.pyx
+++ b/av/subtitles/codeccontext.pyx
@@ -1,17 +1,23 @@
 cimport libav as lib
 
 from av.frame cimport Frame
+from av.packet cimport Packet
 from av.subtitles.subtitle cimport SubtitleProxy, SubtitleSet
 from av.utils cimport err_check
 
 
 cdef class SubtitleCodecContext(CodecContext):
 
-    cdef _decode(self, lib.AVPacket *packet, int *data_consumed):
-
+    cdef _send_packet_and_recv(self, Packet packet):
         cdef SubtitleProxy proxy = SubtitleProxy()
 
         cdef int got_frame = 0
-        data_consumed[0] = err_check(lib.avcodec_decode_subtitle2(self.ptr, &proxy.struct, &got_frame, packet))
+        err_check(lib.avcodec_decode_subtitle2(
+            self.ptr,
+            &proxy.struct,
+            &got_frame,
+            &packet.struct if packet else NULL))
         if got_frame:
-            return SubtitleSet(proxy)
+            return [SubtitleSet(proxy)]
+        else:
+            return []

--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -60,30 +60,6 @@ cdef class VideoCodecContext(CodecContext):
 
         return [vframe]
 
-    cdef _encode(self, Frame frame):
-        """Encodes a frame of video, returns a packet if one is ready.
-
-        The output packet does not necessarily contain data for the most recent frame,
-        as encoders can delay, split, and combine input frames internally as needed.
-        If called with with no args it will flush out the encoder and return the buffered
-        packets until there are none left, at which it will return None.
-
-        """
-
-        cdef VideoFrame vframe = frame
-
-
-        cdef Packet packet = Packet()
-        cdef int got_packet
-
-        if vframe is not None:
-            ret = err_check(lib.avcodec_encode_video2(self.ptr, &packet.struct, vframe.ptr, &got_packet))
-        else:
-            ret = err_check(lib.avcodec_encode_video2(self.ptr, &packet.struct, NULL, &got_packet))
-
-        if got_packet:
-            return packet
-
     cdef Frame _alloc_next_frame(self):
         return alloc_video_frame()
 

--- a/av/video/codeccontext.pyx
+++ b/av/video/codeccontext.pyx
@@ -68,45 +68,6 @@ cdef class VideoCodecContext(CodecContext):
         cdef VideoFrame vframe = frame
         vframe._init_user_attributes()
 
-    cdef _decode(self, lib.AVPacket *packet, int *data_consumed):
-
-        # Create a frame if we don't have one ready.
-        if not self.next_frame:
-            self.next_frame = alloc_video_frame()
-
-        # Decode video into the frame.
-        cdef int completed_frame = 0
-
-        cdef int result
-
-        with nogil:
-            result = lib.avcodec_decode_video2(self.ptr, self.next_frame.ptr, &completed_frame, packet)
-        data_consumed[0] = err_check(result)
-
-        if not completed_frame:
-            return
-
-        # Check if the frame size has changed so that we can always have a
-        # SwsContext that is ready to go.
-        if self.last_w != self.ptr.width or self.last_h != self.ptr.height:
-            self.last_w = self.ptr.width
-            self.last_h = self.ptr.height
-            # TODO codec-ctx: Stream would calculate self.buffer_size here.
-            self.reformatter = VideoReformatter()
-
-        # We are ready to send this one off into the world!
-        cdef VideoFrame frame = self.next_frame
-        self.next_frame = None
-
-        # Share our SwsContext with the frames. Most of the time they will end
-        # up using the same settings as each other, so it makes sense to cache
-        # it like this.
-        # TODO codec-ctx: Stream did this.
-        #frame.reformatter = self.reformatter
-
-        return frame
-
-
     cdef _build_format(self):
         self._format = get_video_format(<lib.AVPixelFormat>self.ptr.pix_fmt, self.ptr.width, self.ptr.height)
 

--- a/include/libav.pxd
+++ b/include/libav.pxd
@@ -6,8 +6,6 @@ cdef extern from "pyav/config.h" nogil:
     char* PYAV_VERSION_STR
     char* PYAV_COMMIT_STR
 
-    int PYAV_HAVE_AVCODEC_SEND_PACKET
-
 
 include "libavutil/avutil.pxd"
 include "libavutil/channel_layout.pxd"

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -272,20 +272,6 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
         void (*destruct)(AVPacket*)
 
 
-    cdef int avcodec_decode_video2(
-        AVCodecContext *ctx,
-        AVFrame *frame,
-        int *got_frame,
-        AVPacket *packet,
-    )
-
-    cdef int avcodec_decode_audio4(
-        AVCodecContext *ctx,
-        AVFrame *frame,
-        int *got_frame,
-        AVPacket *packet,
-    )
-
     cdef int avcodec_fill_audio_frame(
         AVFrame *frame,
         int nb_channels,

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -121,7 +121,6 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
         int flags
         int thread_count
         int thread_type
-        int refcounted_frames
 
         int profile
         AVDiscard skip_frame

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -286,20 +286,6 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
         AVPacket *packet,
     )
 
-    cdef int avcodec_encode_audio2(
-        AVCodecContext *ctx,
-        AVPacket *avpkt,
-        AVFrame *frame,
-        int *got_packet_ptr
-    )
-
-    cdef int avcodec_encode_video2(
-        AVCodecContext *ctx,
-        AVPacket *avpkt,
-        AVFrame *frame,
-        int *got_packet_ptr
-    )
-
     cdef int avcodec_fill_audio_frame(
         AVFrame *frame,
         int nb_channels,

--- a/include/libavcodec/avcodec.pyav.h
+++ b/include/libavcodec/avcodec.pyav.h
@@ -9,17 +9,6 @@
 #endif
 
 
-#if !PYAV_HAVE_AVCODEC_SEND_PACKET
-
-    // Stub these out so that we don't fail to compile.
-    int avcodec_send_packet(AVCodecContext *avctx, AVPacket *packet)   { return 0; }
-    int avcodec_receive_frame(AVCodecContext *avctx, AVFrame *frame)   { return 0; }
-    int avcodec_send_frame(AVCodecContext *avctx, AVFrame *frame)      { return 0; }
-    int avcodec_receive_packet(AVCodecContext *avctx, AVPacket *avpkt) { return 0; }
-
-#endif
-
-
 // Some of these properties don't exist in both FFMpeg and LibAV, so we
 // signal to our code that they are missing via 0.
 #ifndef AV_CODEC_PROP_INTRA_ONLY

--- a/scratchpad/memleak.py
+++ b/scratchpad/memleak.py
@@ -67,7 +67,7 @@ def transcode_level1_to_level3():
 def decode_using_pyav():
 
     print('Decoding using PyAV.')
-    fh = av.open('ffv1_level3.nut', 'r', options={'refcounted_frames': '1'})
+    fh = av.open('ffv1_level3.nut', 'r')
     for s in fh.streams:
         #print s, s.thread_type, s.thread_count
         #pass

--- a/setup.py
+++ b/setup.py
@@ -550,7 +550,6 @@ class ReflectCommand(Command):
             'av_calloc',
             'avformat_alloc_output_context2',
             'avformat_close_input',
-            'avcodec_send_packet',
 
         ):
             print("looking for %s... " % func_name, end='\n' if self.debug else '')

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -14,10 +14,7 @@ class TestSubtitle(TestCase):
         fh = av.open(path)
         subs = []
         for packet in fh.demux():
-            try:
-                subs.extend(packet.decode())
-            except ValueError:
-                raise SkipTest
+            subs.extend(packet.decode())
 
         self.assertEqual(len(subs), 3)
         self.assertIsInstance(subs[0][0], AssSubtitle)
@@ -33,10 +30,7 @@ class TestSubtitle(TestCase):
         fh = av.open(path)
         subs = []
         for packet in fh.demux():
-            try:
-                subs.extend(packet.decode())
-            except ValueError:
-                raise SkipTest
+            subs.extend(packet.decode())
 
         self.assertEqual(len(subs), 43)
 


### PR DESCRIPTION
Since FFmpeg 3.1, the preferred mechanism for encoding / decoding audio and video is using a send / receive mechanisms instead of calling avcodec_xxx_encode and avcodec_xxx_decode methods.

Now that our baseline is FFmpeg 3.2 we can remove the legacy code, which fixes a number of deprecation warnings.