### PR TITLE
Add support for more ndarray <-> VideoFrame conversions

### DIFF
--- a/av/video/frame.pxd
+++ b/av/video/frame.pxd
@@ -17,7 +17,7 @@ cdef class VideoFrame(Frame):
 
     cdef readonly VideoFormat format
 
-    cdef _init(self, lib.AVPixelFormat format, unsigned int width, unsigned int height)
+    cdef _init(self, lib.AVPixelFormat format, unsigned int width, unsigned int height, unsigned int align)
     cdef _init_user_attributes(self)
 
     cdef _reformat(self, unsigned int width, unsigned int height, lib.AVPixelFormat format, int src_colorspace, int dst_colorspace)

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -1,5 +1,6 @@
 import warnings
 
+import numpy
 from av import VideoFrame
 from av.deprecation import AttributeRenamedWarning
 
@@ -45,6 +46,21 @@ class TestVideoFramePlanes(TestCase):
             self.assertEqual(frame.planes[i].height, 240)
             self.assertEqual(frame.planes[i].line_size, 320)
             self.assertEqual(frame.planes[i].buffer_size, 320 * 240)
+
+    def test_yuv420p_planes_align(self):
+        # If we request 8-byte alignment for a width which is not a multiple of 8,
+        # the line sizes are larger than the plane width.
+        frame = VideoFrame(318, 238, 'yuv420p', align=8)
+        self.assertEqual(len(frame.planes), 3)
+        self.assertEqual(frame.planes[0].width, 318)
+        self.assertEqual(frame.planes[0].height, 238)
+        self.assertEqual(frame.planes[0].line_size, 320)
+        self.assertEqual(frame.planes[0].buffer_size, 320 * 238)
+        for i in range(1, 3):
+            self.assertEqual(frame.planes[i].width, 159)
+            self.assertEqual(frame.planes[i].height, 119)
+            self.assertEqual(frame.planes[i].line_size, 160)
+            self.assertEqual(frame.planes[i].buffer_size, 160 * 119)
 
     def test_rgb24_planes(self):
         frame = VideoFrame(640, 480, 'rgb24')
@@ -130,6 +146,77 @@ class TestVideoFrameConveniences(TestCase):
         self.assertEqual(
             str(recorded[0].message),
             'VideoFrame.to_nd_array is deprecated; please use VideoFrame.to_ndarray.')
+
+    def test_ndarray_gray(self):
+        array = numpy.random.randint(0, 256, size=(480, 640), dtype=numpy.uint8)
+        for format in ['gray', 'gray8']:
+            frame = VideoFrame.from_ndarray(array, format=format)
+            self.assertEqual(frame.width, 640)
+            self.assertEqual(frame.height, 480)
+            self.assertEqual(frame.format.name, 'gray')
+            self.assertTrue((frame.to_ndarray() == array).all())
+
+    def test_ndarray_gray_align_8(self):
+        for format in ['gray', 'gray8']:
+            frame = VideoFrame(318, 238, format=format, align=8)
+            array = frame.to_ndarray()
+            self.assertEqual(array.shape, (238, 318))
+
+    def test_ndarray_rgb(self):
+        array = numpy.random.randint(0, 256, size=(480, 640, 3), dtype=numpy.uint8)
+        for format in ['rgb24', 'bgr24']:
+            frame = VideoFrame.from_ndarray(array, format=format)
+            self.assertEqual(frame.width, 640)
+            self.assertEqual(frame.height, 480)
+            self.assertEqual(frame.format.name, format)
+            self.assertTrue((frame.to_ndarray() == array).all())
+
+    def test_ndarray_rgb_align_8(self):
+        for format in ['rgb24', 'bgr24']:
+            frame = VideoFrame(318, 238, format=format, align=8)
+            array = frame.to_ndarray()
+            self.assertEqual(array.shape, (238, 318, 3))
+
+    def test_ndarray_rgba(self):
+        array = numpy.random.randint(0, 256, size=(480, 640, 4), dtype=numpy.uint8)
+        for format in ['argb', 'rgba', 'abgr', 'bgra']:
+            frame = VideoFrame.from_ndarray(array, format=format)
+            self.assertEqual(frame.width, 640)
+            self.assertEqual(frame.height, 480)
+            self.assertEqual(frame.format.name, format)
+            self.assertTrue((frame.to_ndarray() == array).all())
+
+    def test_ndarray_rgba_align_8(self):
+        for format in ['argb', 'rgba', 'abgr', 'bgra']:
+            frame = VideoFrame(318, 238, format=format, align=8)
+            array = frame.to_ndarray()
+            self.assertEqual(array.shape, (238, 318, 4))
+
+    def test_ndarray_yuv420p(self):
+        array = numpy.random.randint(0, 256, size=(720, 640), dtype=numpy.uint8)
+        frame = VideoFrame.from_ndarray(array, format='yuv420p')
+        self.assertEqual(frame.width, 640)
+        self.assertEqual(frame.height, 480)
+        self.assertEqual(frame.format.name, 'yuv420p')
+        self.assertTrue((frame.to_ndarray() == array).all())
+
+    def test_ndarray_yuv420p_align_8(self):
+        frame = VideoFrame(318, 238, format='yuv420p', align=8)
+        array = frame.to_ndarray()
+        self.assertEqual(array.shape, (357, 318))
+
+    def test_ndarray_yuyv422(self):
+        array = numpy.random.randint(0, 256, size=(480, 640, 2), dtype=numpy.uint8)
+        frame = VideoFrame.from_ndarray(array, format='yuyv422')
+        self.assertEqual(frame.width, 640)
+        self.assertEqual(frame.height, 480)
+        self.assertEqual(frame.format.name, 'yuyv422')
+        self.assertTrue((frame.to_ndarray() == array).all())
+
+    def test_ndarray_yuyv422_align_8(self):
+        frame = VideoFrame(318, 238, format='yuyv422', align=8)
+        array = frame.to_ndarray()
+        self.assertEqual(array.shape, (238, 318, 2))
 
 
 class TestVideoFrameTiming(TestCase):


### PR DESCRIPTION
We support round-tripping:

- 24-bit RGB
- 32-bit RGBA (new)
- 8-bit grayscale (new)
- yuv420p (new)
- yuyv422 (new)

We drop the gray16 conversion code as it was not handling byte order
correctly, and could not be triggered anyway due to an impossible test:

  frame.format.name == ('gray16le', 'gray16be')