### PR TITLE
Fix const warnings on iterator shims

### DIFF
--- a/av/codec/codec-shims.c
+++ b/av/codec/codec-shims.c
@@ -2,15 +2,15 @@
 #include "libavcodec/avcodec.h"
 
 
-const AVCodec* pyav_codec_iterate(const void **handle) {
+const AVCodec* pyav_codec_iterate(void **opaque) {
 
 #if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(58, 10, 100)
-    return av_codec_iterate(handle);
+    return av_codec_iterate(opaque);
 
 #else
     const AVCodec *ptr;
-    ptr = av_codec_next(*handle);
-    *handle = ptr;
+    ptr = av_codec_next((const AVCodec*)*opaque);
+    *opaque = (void*)ptr;
     return ptr;
 
 #endif

--- a/av/codec/codec.pyx
+++ b/av/codec/codec.pyx
@@ -5,7 +5,7 @@ from av.video.format cimport get_video_format
 
 
 cdef extern from "codec-shims.c" nogil:
-    cdef const lib.AVCodec* pyav_codec_iterate(void **handle)
+    cdef const lib.AVCodec* pyav_codec_iterate(void **opaque)
 
 
 cdef object _cinit_sentinel = object()
@@ -249,7 +249,7 @@ cdef class Codec(object):
 cdef get_codec_names():
     names = set()
     cdef const lib.AVCodec *ptr
-    cdef const void *opaque = NULL
+    cdef void *opaque = NULL
     while True:
         ptr = pyav_codec_iterate(&opaque);
         if ptr:

--- a/av/filter/filter-shims.c
+++ b/av/filter/filter-shims.c
@@ -1,14 +1,14 @@
 #include "libavfilter/avfilter.h"
 
-const AVFilter* pyav_filter_iterate(const void **handle) {
+const AVFilter* pyav_filter_iterate(void **opaque) {
 
 #if LIBAVFILTER_VERSION_INT >= AV_VERSION_INT(7, 14, 100)
-    return av_filter_iterate(handle);
+    return av_filter_iterate(opaque);
 
 #else
     const AVFilter *ptr;
-    ptr = avfilter_next(*handle);
-    *handle = ptr;
+    ptr = avfilter_next((const AVFilter*)*opaque);
+    *opaque = (void*)ptr;
     return ptr;
 
 #endif

--- a/av/filter/filter.pyx
+++ b/av/filter/filter.pyx
@@ -4,7 +4,7 @@ from av.descriptor cimport wrap_avclass
 from av.filter.pad cimport alloc_filter_pads
 
 cdef extern from "filter-shims.c" nogil:
-    cdef const lib.AVFilter* pyav_filter_iterate(void **handle)
+    cdef const lib.AVFilter* pyav_filter_iterate(void **opaque)
 
 
 cdef object _cinit_sentinel = object()
@@ -95,7 +95,7 @@ cdef class Filter(object):
 cdef get_filter_names():
     names = set()
     cdef const lib.AVFilter *ptr
-    cdef const void *opaque = NULL
+    cdef void *opaque = NULL
     while True:
         ptr = pyav_filter_iterate(&opaque);
         if ptr:

--- a/av/format-shims.c
+++ b/av/format-shims.c
@@ -26,30 +26,30 @@ AVOutputFormat* pyav_find_output_format(const char *name) {
 }
 
 
-const AVOutputFormat* pyav_muxer_iterate(const void **handle) {
+const AVOutputFormat* pyav_muxer_iterate(void **opaque) {
 
 #if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(58, 9, 100)
-    return av_muxer_iterate(handle);
+    return av_muxer_iterate(opaque);
 
 #else
     const AVOutputFormat *ptr;
-    ptr = av_oformat_next(*handle);
-    *handle = ptr;
+    ptr = av_oformat_next((const AVOutputFormat*)*opaque);
+    *opaque = (void*)ptr;
     return ptr;
 
 #endif
 }
 
 
-const AVInputFormat* pyav_demuxer_iterate(const void **handle) {
+const AVInputFormat* pyav_demuxer_iterate(void **opaque) {
 
 #if LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(58, 9, 100)
-    return av_demuxer_iterate(handle);
+    return av_demuxer_iterate(opaque);
 
 #else
     const AVInputFormat *ptr;
-    ptr = av_iformat_next(*handle);
-    *handle = ptr;
+    ptr = av_iformat_next((const AVInputFormat*)*opaque);
+    *opaque = (void*)ptr;
     return ptr;
 
 #endif

--- a/av/format.pyx
+++ b/av/format.pyx
@@ -5,8 +5,8 @@ from av.descriptor cimport wrap_avclass
 
 cdef extern from "format-shims.c" nogil:
     cdef const lib.AVOutputFormat* pyav_find_output_format(const char *name)
-    cdef const lib.AVOutputFormat* pyav_muxer_iterate(void **handle)
-    cdef const lib.AVInputFormat* pyav_demuxer_iterate(void **handle)
+    cdef const lib.AVOutputFormat* pyav_muxer_iterate(void **opaque)
+    cdef const lib.AVInputFormat* pyav_demuxer_iterate(void **opaque)
 
 
 cdef object _cinit_bypass_sentinel = object()
@@ -112,7 +112,7 @@ cdef class ContainerFormat(object):
 cdef get_output_format_names():
     names = set()
     cdef const lib.AVOutputFormat *ptr
-    cdef const void *opaque = NULL
+    cdef void *opaque = NULL
     while True:
         ptr = pyav_muxer_iterate(&opaque);
         if ptr:
@@ -124,7 +124,7 @@ cdef get_output_format_names():
 cdef get_input_format_names():
     names = set()
     cdef const lib.AVInputFormat *ptr
-    cdef const void *opaque = NULL
+    cdef void *opaque = NULL
     while True:
         ptr = pyav_demuxer_iterate(&opaque);
         if ptr:


### PR DESCRIPTION
The current code spews warnings both for old and new FFmpegs. This PR fixes the warnings by:
    
- aligning function prototypes on FFmpeg 4.0's (fixes new FFmpegs)
- adding the necessary casts for older FFmpegs

This completes the work done in #412.