### PR TITLE
Fix constness warnings for AVOption

### DIFF
--- a/av/descriptor.pyx
+++ b/av/descriptor.pyx
@@ -24,8 +24,8 @@ cdef class Descriptor(object):
 
     property options:
         def __get__(self):
-            cdef lib.AVOption *ptr = self.ptr.option
-            cdef lib.AVOption *choice_ptr
+            cdef const lib.AVOption *ptr = self.ptr.option
+            cdef const lib.AVOption *choice_ptr
             cdef Option option
             cdef OptionChoice option_choice
             cdef bint choice_is_default

--- a/av/option.pxd
+++ b/av/option.pxd
@@ -3,7 +3,7 @@ cimport libav as lib
 
 cdef class BaseOption(object):
 
-    cdef lib.AVOption *ptr
+    cdef const lib.AVOption *ptr
 
 
 cdef class Option(BaseOption):
@@ -16,6 +16,6 @@ cdef class OptionChoice(BaseOption):
     cdef readonly bint is_default
 
 
-cdef Option wrap_option(tuple choices, lib.AVOption *ptr)
+cdef Option wrap_option(tuple choices, const lib.AVOption *ptr)
 
-cdef OptionChoice wrap_option_choice(lib.AVOption *ptr, bint is_default)
+cdef OptionChoice wrap_option_choice(const lib.AVOption *ptr, bint is_default)

--- a/av/option.pyx
+++ b/av/option.pyx
@@ -6,7 +6,7 @@ from av.enums cimport EnumType, define_enum
 
 cdef object _cinit_sentinel = object()
 
-cdef Option wrap_option(tuple choices, lib.AVOption *ptr):
+cdef Option wrap_option(tuple choices, const lib.AVOption *ptr):
     if ptr == NULL:
         return None
     cdef Option obj = Option(_cinit_sentinel)
@@ -155,7 +155,7 @@ cdef class Option(BaseOption):
         )
 
 
-cdef OptionChoice wrap_option_choice(lib.AVOption *ptr, bint is_default):
+cdef OptionChoice wrap_option_choice(const lib.AVOption *ptr, bint is_default):
     if ptr == NULL:
         return None
     cdef OptionChoice obj = OptionChoice(_cinit_sentinel)

--- a/include/libavutil/avutil.pxd
+++ b/include/libavutil/avutil.pxd
@@ -316,7 +316,7 @@ cdef extern from "libavutil/log.h" nogil:
         AVClassCategory category
         int parent_log_context_offset
 
-        AVOption *option
+        const AVOption *option
 
     cdef enum:
         AV_LOG_QUIET


### PR DESCRIPTION
All AVOption manipulation should be done on const pointers, including
the AVClass.option definition, see:

https://www.ffmpeg.org/doxygen/4.0/structAVClass.html