### PR TITLE
Fix buffer_size calculations for AudioFrame planes

### DIFF
--- a/av/audio/frame.pxd
+++ b/av/audio/frame.pxd
@@ -13,10 +13,6 @@ cdef class AudioFrame(Frame):
     cdef uint8_t *_buffer
     cdef size_t _buffer_size
 
-    cdef bint align
-    cdef int nb_channels
-    cdef int nb_planes
-
     cdef readonly AudioLayout layout
     """
     The audio channel layout.
@@ -31,8 +27,7 @@ cdef class AudioFrame(Frame):
     :type: AudioFormat
     """
 
-    cdef _init(self, lib.AVSampleFormat format, uint64_t layout, unsigned int nb_samples, bint align)
-    cdef _recalc_linesize(self)
+    cdef _init(self, lib.AVSampleFormat format, uint64_t layout, unsigned int nb_samples, unsigned int align)
     cdef _init_user_attributes(self)
 
 cdef AudioFrame alloc_audio_frame()

--- a/av/audio/plane.pyx
+++ b/av/audio/plane.pyx
@@ -6,17 +6,8 @@ from av.audio.frame cimport AudioFrame
 cdef class AudioPlane(Plane):
 
     def __cinit__(self, AudioFrame frame, int index):
-
-        # We have to calculate this manually, since the provided linesize
-        # array of the AVFrame only sets the first element, and does not
-        # even seem to calculate it properly.
-        lib.av_samples_get_buffer_size(
-            <int*>&self.buffer_size,
-            frame.nb_channels,
-            frame.ptr.nb_samples,
-            <lib.AVSampleFormat>frame.ptr.format,
-            frame.align
-        )
+        # Only the first linesize is ever populated, but it applies to every plane.
+        self.buffer_size = self.frame.ptr.linesize[0]
 
     cdef size_t _buffer_size(self):
         return self.buffer_size

--- a/av/audio/resampler.pyx
+++ b/av/audio/resampler.pyx
@@ -186,8 +186,4 @@ cdef class AudioResampler(object):
 
         self.samples_out += output.ptr.nb_samples
 
-        # Recalculate linesize since the initial number of samples was
-        # only an estimate.
-        output._recalc_linesize()
-
         return output

--- a/av/plane.pyx
+++ b/av/plane.pyx
@@ -15,19 +15,7 @@ cdef class Plane(Buffer):
     def __repr__(self):
         return '<av.%s at 0x%x>' % (self.__class__.__name__, id(self))
 
-    property line_size:
-        """
-        Bytes per horizontal line in this plane.
-
-        :type: int
-        """
-        def __get__(self):
-            return self.frame.ptr.linesize[self.index]
-
     ptr = renamed_attr('buffer_ptr')
-
-    cdef size_t _buffer_size(self):
-        return self.frame.ptr.linesize[self.index]
 
     cdef void*  _buffer_ptr(self):
         return self.frame.ptr.extended_data[self.index]

--- a/av/video/plane.pyx
+++ b/av/video/plane.pyx
@@ -20,6 +20,15 @@ cdef class VideoPlane(Plane):
     cdef size_t _buffer_size(self):
         return self.buffer_size
 
+    property line_size:
+        """
+        Bytes per horizontal line in this plane.
+
+        :type: int
+        """
+        def __get__(self):
+            return self.frame.ptr.linesize[self.index]
+
     property width:
         """Pixel width of this plane."""
         def __get__(self):

--- a/tests/test_audioframe.py
+++ b/tests/test_audioframe.py
@@ -15,18 +15,53 @@ class TestAudioFrameConstructors(TestCase):
         self.assertEqual(len(frame.planes), 0)
         self.assertEqual(frame.samples, 0)
 
+    def test_manual_flt_mono_constructor(self):
+        frame = AudioFrame(format='flt', layout='mono', samples=160)
+        self.assertEqual(frame.format.name, 'flt')
+        self.assertEqual(frame.layout.name, 'mono')
+        self.assertEqual(len(frame.planes), 1)
+        self.assertEqual(frame.planes[0].buffer_size, 640)
+        self.assertEqual(frame.samples, 160)
+
+    def test_manual_flt_stereo_constructor(self):
+        frame = AudioFrame(format='flt', layout='stereo', samples=160)
+        self.assertEqual(frame.format.name, 'flt')
+        self.assertEqual(frame.layout.name, 'stereo')
+        self.assertEqual(len(frame.planes), 1)
+        self.assertEqual(frame.planes[0].buffer_size, 1280)
+        self.assertEqual(frame.samples, 160)
+
+    def test_manual_fltp_stereo_constructor(self):
+        frame = AudioFrame(format='fltp', layout='stereo', samples=160)
+        self.assertEqual(frame.format.name, 'fltp')
+        self.assertEqual(frame.layout.name, 'stereo')
+        self.assertEqual(len(frame.planes), 2)
+        self.assertEqual(frame.planes[0].buffer_size, 640)
+        self.assertEqual(frame.planes[1].buffer_size, 640)
+        self.assertEqual(frame.samples, 160)
+
     def test_manual_s16_mono_constructor(self):
         frame = AudioFrame(format='s16', layout='mono', samples=160)
         self.assertEqual(frame.format.name, 's16')
         self.assertEqual(frame.layout.name, 'mono')
         self.assertEqual(len(frame.planes), 1)
+        self.assertEqual(frame.planes[0].buffer_size, 320)
         self.assertEqual(frame.samples, 160)
+
+    def test_manual_s16_mono_constructor_align_8(self):
+        frame = AudioFrame(format='s16', layout='mono', samples=159, align=8)
+        self.assertEqual(frame.format.name, 's16')
+        self.assertEqual(frame.layout.name, 'mono')
+        self.assertEqual(len(frame.planes), 1)
+        self.assertEqual(frame.planes[0].buffer_size, 320)
+        self.assertEqual(frame.samples, 159)
 
     def test_manual_s16_stereo_constructor(self):
         frame = AudioFrame(format='s16', layout='stereo', samples=160)
         self.assertEqual(frame.format.name, 's16')
         self.assertEqual(frame.layout.name, 'stereo')
         self.assertEqual(len(frame.planes), 1)
+        self.assertEqual(frame.planes[0].buffer_size, 640)
         self.assertEqual(frame.samples, 160)
 
     def test_manual_s16p_stereo_constructor(self):
@@ -34,6 +69,8 @@ class TestAudioFrameConstructors(TestCase):
         self.assertEqual(frame.format.name, 's16p')
         self.assertEqual(frame.layout.name, 'stereo')
         self.assertEqual(len(frame.planes), 2)
+        self.assertEqual(frame.planes[0].buffer_size, 320)
+        self.assertEqual(frame.planes[1].buffer_size, 320)
         self.assertEqual(frame.samples, 160)
 
 


### PR DESCRIPTION
This PR fixes several misunderstandings concerning AudioFrame buffer
sizes:

- for audio, "line size" and "buffer size" are equivalent, as there is
only ever a single "line".

- only linesizes[0] is ever populated, and it gives you the buffer size
of each plane.

- we do not need to recalculate anything upon putting frames into an
AudioFrame, the buffer size does not change.

- "align" is not a boolean, it can be any power of two.

We stop carrying around "align", "nb_channels" and "nb_planes", they are
not needed.