### PR TITLE
Fix VideoFrame.to_image / .from_image alignment

### DIFF
--- a/av/video/frame.pxd
+++ b/av/video/frame.pxd
@@ -17,7 +17,7 @@ cdef class VideoFrame(Frame):
 
     cdef readonly VideoFormat format
 
-    cdef _init(self, lib.AVPixelFormat format, unsigned int width, unsigned int height, unsigned int align)
+    cdef _init(self, lib.AVPixelFormat format, unsigned int width, unsigned int height)
     cdef _init_user_attributes(self)
 
     cdef _reformat(self, unsigned int width, unsigned int height, lib.AVPixelFormat format, int src_colorspace, int dst_colorspace)


### PR DESCRIPTION
The previous implementation of .to_image() only worked if the
VideoFrame's line size matched the image width.