### PR TITLE
Remove Stream.seek method (fixes: #428)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,10 @@ Major:
 
 - Dropped support for FFmpeg < 3.2.
 
+Minor:
+
+- Remove :meth:`.Stream.seek` method, as it actually makes the whole container seek.
+  Please use :meth:`.InputContainer.seek` instead.
 
 v0.x.y
 ------

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -127,16 +127,6 @@ cdef class Stream(object):
     def decode(self, packet=None):
         return self.codec_context.decode(packet)
 
-    def seek(self, offset, whence='time', backward=True, any_frame=False):
-        """seek(offset, whence='time', backward=True, any_frame=False)
-
-        .. seealso:: :meth:`.InputContainer.seek` for documentation on parameters.
-            The only difference is that ``offset`` will be interpreted in
-            :attr:`.Stream.time_base` when ``whence == 'time'``.
-
-        """
-        self._container.seek(self._stream.index, offset, whence, backward, any_frame)
-
     property id:
         def __get__(self):
             return self._stream.id

--- a/tests/test_seek.py
+++ b/tests/test_seek.py
@@ -28,7 +28,6 @@ class TestSeek(TestCase):
     def test_seek_float(self):
         container = av.open(fate_suite('h264/interlaced_crop.mp4'))
         self.assertRaises(TypeError, container.seek, 1.0)
-        self.assertRaises(TypeError, container.streams.video[0].seek, 1.0)
 
     def test_seek_int64(self):
         # Assert that it accepts large values.
@@ -121,45 +120,6 @@ class TestSeek(TestCase):
             for frame in packet.decode():
                 if current_frame is None:
                     current_frame = timestamp_to_frame(frame.pts, video_stream)
-                else:
-                    current_frame += 1
-
-                # start counting once we reach the target frame
-                if current_frame is not None and current_frame >= target_frame:
-                    frame_count += 1
-
-        self.assertEqual(frame_count, total_frame_count - target_frame)
-
-    def test_stream_seek(self):
-
-        container = av.open(fate_suite('h264/interlaced_crop.mp4'))
-
-        video_stream = next(s for s in container.streams if s.type == 'video')
-        total_frame_count = 0
-
-        # Count number of frames in video
-        for packet in container.demux(video_stream):
-            for frame in packet.decode():
-                total_frame_count += 1
-
-        target_frame = int(total_frame_count / 2.0)
-        time_base = float(video_stream.time_base)
-
-        rate = float(video_stream.average_rate)
-        target_sec = target_frame * 1 / rate
-
-        target_timestamp = int(target_sec / time_base) + video_stream.start_time
-
-        video_stream.seek(target_timestamp)
-
-        current_frame = None
-        frame_count = 0
-
-        for packet in container.demux(video_stream):
-            for frame in packet.decode():
-                if current_frame is None:
-                    current_frame = timestamp_to_frame(frame.pts, video_stream)
-
                 else:
                     current_frame += 1
 


### PR DESCRIPTION
This method is semantically incorrect, as it makes the whole container
seek to a different position.