### PR TITLE
Fix memory leak in OutputContainer.mux_one (fixes: #431)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,7 @@ Minor:
   (:issue:`424`).
 - Ensure :meth:`OutputContainer.close` is called at destruction (:issue:`427`).
 - Fix a memory leak in :class:`.OutputContainer` initialisation (:issue:`427`).
+- Fix a memory leak in :meth:`.OutputContainer.mux_one` (:issue:`431`).
 
 Build:
 

--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -215,6 +215,8 @@ cdef class OutputContainer(Container):
 
         # Make another reference to the packet, as av_interleaved_write_frame
         # takes ownership of it.
-        cdef lib.AVPacket *packet_ref = lib.av_packet_clone(&packet.struct)
+        cdef lib.AVPacket packet_ref
+        lib.av_init_packet(&packet_ref)
+        self.proxy.err_check(lib.av_packet_ref(&packet_ref, &packet.struct))
 
-        self.proxy.err_check(lib.av_interleaved_write_frame(self.proxy.ptr, packet_ref))
+        self.proxy.err_check(lib.av_interleaved_write_frame(self.proxy.ptr, &packet_ref))

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -280,10 +280,8 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
 
     cdef void av_init_packet(AVPacket*)
     cdef int av_new_packet(AVPacket*, int)
+    cdef int av_packet_ref(AVPacket *dst, const AVPacket *src)
     cdef void av_packet_unref(AVPacket *pkt)
-    cdef int av_copy_packet(AVPacket *dst, AVPacket *src)
-    cdef AVPacket* av_packet_clone(AVPacket *src)
-    cdef int av_dup_packet(AVPacket *pkt)
 
     cdef enum AVSubtitleType:
         SUBTITLE_NONE


### PR DESCRIPTION
av_packet_clone both allocates an AVPacket structure and makes a new
reference to the underlying buffer. av_interleaved_write_frame only calls
av_packet_unref when it's done with the packet, it doesn't actually free it.