### PR TITLE
Fix memory leak with Python I/O (fixes: #317)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Minor:
 - Ensure :meth:`OutputContainer.close` is called at destruction (:issue:`427`).
 - Fix a memory leak in :class:`.OutputContainer` initialisation (:issue:`427`).
 - Fix a memory leak in :meth:`.OutputContainer.mux_one` (:issue:`431`).
+- Fix a memory leak when using Python I/O (:issue:`317`).
 
 Build:
 


### PR DESCRIPTION
When using "custom I/O", avformat_close_input will not call avio_close
so it is up to us to clean up.