### PR TITLE
Assert PyAV is built against a compatible FFmpeg (fixes: #401)

### DIFF
--- a/include/libavcodec/avcodec.pyav.h
+++ b/include/libavcodec/avcodec.pyav.h
@@ -1,13 +1,8 @@
 #include "libavcodec/avcodec.h"
 
-
-#if PYAV_HAVE_FFMPEG
-
-    #define AVPixelFormat PixelFormat
-    #define AV_PIX_FMT_YUV420P PIX_FMT_YUV420P
-
+#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(57, 64, 100)
+    #error FFmpeg 3.2 or higher is required
 #endif
-
 
 // Some of these properties don't exist in both FFMpeg and LibAV, so we
 // signal to our code that they are missing via 0.


### PR DESCRIPTION
We explicitly fail the build as early as possible if a build is
attempted against an unsupported FFmpeg version. This gives users a
clear indication of what is wrong instead of triggering obscure
compiler errors about missing functions or struct members.

We also remove the reference to PYAV_HAVE_FFMPEG which is not defined
anymore.