### PR TITLE
Remove DataStream.seek override (fixes: #299)

### DIFF
--- a/av/data/stream.pyx
+++ b/av/data/stream.pyx
@@ -18,9 +18,6 @@ cdef class DataStream(Stream):
     def decode(self, packet=None, count=0):
         pass
 
-    def seek(self, timestamp, mode='time', backward=True, any_frame=False):
-        pass
-
     property name:
         def __get__(self):
             cdef const lib.AVCodecDescriptor *desc = lib.avcodec_descriptor_get(self._codec_context.codec_id)


### PR DESCRIPTION
Its signature does not match Stream.seek, leading to the bug mentioned
in #299.

Furthermore, this method does nothing, where as the base Stream.seek
should work for any kind of stream.