### PR TITLE
Cleanup tests and examples

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -34,7 +34,7 @@ You can use the same build system as Travis for local development::
     make
 
     # Run the tests.
-    nosetests
+    make test
 
 
 Time in Libraries

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ install:
   - conda update conda
   - conda install --yes conda-build jinja2 anaconda-client
   - conda create -q -n test-environment python=%PYTHON_VERSION%
-    pip "setuptools>=0.24" Pillow "Cython>=0.22" "nose>=1.3"
+    pip "setuptools>=0.24" Pillow "Cython>=0.27" "nose>=1.3"
     "numpy>=1.9" "wheel>=0.24" ffmpeg=%FFMPEG_VERSION% msinttypes
   - activate test-environment
 
@@ -92,7 +92,7 @@ before_test:
 
 test_script:
   # Build the compiled extension and run the project tests
-  - "%CMD_IN_ENV% nosetests"
+  - "%CMD_IN_ENV% python setup.py test"
 
 after_test:
   # If tests are successful, create binary packages for the project.

--- a/av/__init__.py
+++ b/av/__init__.py
@@ -21,6 +21,7 @@ from av.codec.codec import Codec, codecs_available
 from av.codec.context import CodecContext
 from av.container import open
 from av.format import ContainerFormat, formats_available
+from av.packet import Packet
 from av.utils import AVError
 from av.video.format import VideoFormat
 from av.video.frame import VideoFrame

--- a/examples/basics/remux.py
+++ b/examples/basics/remux.py
@@ -1,7 +1,6 @@
 import av
 import av.datasets
 
-
 input_ = av.open(av.datasets.curated('pexels/time-lapse-video-of-night-sky-857195.mp4'))
 output = av.open('remuxed.mkv', 'w')
 

--- a/examples/basics/save_keyframes.py
+++ b/examples/basics/save_keyframes.py
@@ -1,7 +1,6 @@
 import av
 import av.datasets
 
-
 container = av.open(av.datasets.curated('pexels/time-lapse-video-of-night-sky-857195.mp4'))
 
 
@@ -18,4 +17,3 @@ for frame in container.decode(stream):
         'night-sky.{:04d}.jpg'.format(frame.pts),
         quality=80,
     )
-

--- a/examples/basics/thread_type.py
+++ b/examples/basics/thread_type.py
@@ -3,7 +3,6 @@ import time
 import av
 import av.datasets
 
-
 print("Decoding with default (slice) threading...")
 
 container = av.open(av.datasets.curated('pexels/time-lapse-video-of-night-sky-857195.mp4'))
@@ -35,4 +34,3 @@ auto_time = time.time() - start_time
 
 print("Decoded with default threading in {:.2f}s.".format(default_time))
 print("Decoded with auto threading in {:.2f}s.".format(auto_time))
-

--- a/examples/numpy/barcode.py
+++ b/examples/numpy/barcode.py
@@ -1,13 +1,11 @@
-from PIL import Image
 import numpy as np
+from PIL import Image
 
 import av
 import av.datasets
 
-
-
 container = av.open(av.datasets.curated('pexels/time-lapse-video-of-sunset-by-the-sea-854400.mp4'))
-container.streams.video[0].thread_type = 'AUTO' # Go faster!
+container.streams.video[0].thread_type = 'AUTO'  # Go faster!
 
 columns = []
 for frame in container.decode(video=0):

--- a/examples/numpy/generate_video.py
+++ b/examples/numpy/generate_video.py
@@ -1,10 +1,9 @@
 
 from __future__ import division
 
-import av
-
 import numpy as np
 
+import av
 
 duration = 4
 fps = 24

--- a/scripts/test
+++ b/scripts/test
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [[ ! "$_PYAV_ACTIVATED" ]]; then
     export here="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"
     source "$here/activate.sh"
@@ -7,4 +9,6 @@ fi
 
 cd "$PYAV_ROOT"
 
-$PYAV_PYTHON -m nose -v || exit 1
+$PYAV_PYTHON -m flake8 examples tests
+$PYAV_PYTHON -m isort -df -rc examples tests
+$PYAV_PYTHON setup.py test

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[flake8]
+max-line-length = 140
+
 [metadata]
 license = BSD
 long_description = file: README.md

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,16 +1,14 @@
 from __future__ import division
 
-from fractions import Fraction
-from subprocess import check_call
-from unittest import TestCase as _Base
 import datetime
 import errno
+import functools
 import os
 import sys
-import functools
 import types
+from unittest import TestCase as _Base
 
-from nose.plugins.skip import SkipTest
+from av.datasets import fate as fate_suite
 
 try:
     import PIL.Image as Image
@@ -18,26 +16,12 @@ try:
 except ImportError:
     Image = ImageFilter = None
 
-import av
-from av.audio import AudioFrame
-from av.buffer import Buffer
-from av.codec import Codec, CodecContext
-from av.datasets import fate as fate_suite
-from av.frame import Frame
-from av.packet import Packet
-from av.stream import Stream
-from av.utils import AVError
-from av.video import VideoFrame
-
 
 is_py3 = sys.version_info[0] > 2
 is_windows = os.name == 'nt'
 
 if not is_py3:
     from itertools import izip as zip
-
-
-
 
 
 def makedirs(path):
@@ -73,6 +57,7 @@ def asset(*args):
 
 # Store all of the sample data here.
 os.environ['PYAV_TESTDATA_DIR'] = asset()
+
 
 def fate_png():
     return fate_suite('png1/55c99e750a5fd6_50314226.png')
@@ -110,7 +95,6 @@ class MethodLogger(object):
 
     def _filter(self, type_):
         return [log for log in self._log if log[0] == type_]
-
 
 
 class TestCase(_Base):

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,8 @@
 autopep8
 Cython
 editorconfig
+flake8
+isort
 nose
 numpy
 Pillow

--- a/tests/test_audiofifo.py
+++ b/tests/test_audiofifo.py
@@ -1,5 +1,6 @@
-from __future__ import print_function
-from .common import *
+import av
+
+from .common import TestCase, fate_suite
 
 
 class TestAudioFifo(TestCase):
@@ -57,7 +58,7 @@ class TestAudioFifo(TestCase):
         self.assertEqual(oframe.pts, 512)
         self.assertEqual(oframe.time_base, iframe.time_base)
 
-        iframe.pts = 9999 # Wrong!
+        iframe.pts = 9999  # Wrong!
         self.assertRaises(ValueError, fifo.write, iframe)
 
     def test_pts_complex(self):

--- a/tests/test_audioformat.py
+++ b/tests/test_audioformat.py
@@ -1,6 +1,8 @@
-from .common import *
-from av.audio.format import AudioFormat
+import sys
 
+from av import AudioFormat
+
+from .common import TestCase
 
 postfix = 'le' if sys.byteorder == 'little' else 'be'
 

--- a/tests/test_audioframe.py
+++ b/tests/test_audioframe.py
@@ -1,6 +1,7 @@
 import warnings
 
 import numpy
+
 from av import AudioFrame
 from av.deprecation import AttributeRenamedWarning
 

--- a/tests/test_audiolayout.py
+++ b/tests/test_audiolayout.py
@@ -1,5 +1,6 @@
-from .common import *
-from av.audio.layout import AudioLayout
+from av import AudioLayout
+
+from .common import TestCase
 
 
 class TestAudioLayout(TestCase):

--- a/tests/test_audioresampler.py
+++ b/tests/test_audioresampler.py
@@ -1,5 +1,6 @@
-from __future__ import print_function
-from .common import *
+from av import AudioFrame, AudioResampler
+
+from .common import TestCase
 
 
 class TestAudioResampler(TestCase):
@@ -8,7 +9,7 @@ class TestAudioResampler(TestCase):
 
         # If we don't ask it to do anything, it won't.
 
-        resampler = av.AudioResampler()
+        resampler = AudioResampler()
 
         iframe = AudioFrame('s16', 'stereo', 1024)
         oframe = resampler.resample(iframe)
@@ -19,7 +20,7 @@ class TestAudioResampler(TestCase):
 
         # If the frames match, it won't do anything.
 
-        resampler = av.AudioResampler('s16', 'stereo')
+        resampler = AudioResampler('s16', 'stereo')
 
         iframe = AudioFrame('s16', 'stereo', 1024)
         oframe = resampler.resample(iframe)
@@ -28,7 +29,7 @@ class TestAudioResampler(TestCase):
 
     def test_pts_assertion_same_rate(self):
 
-        resampler = av.AudioResampler('s16', 'mono')
+        resampler = AudioResampler('s16', 'mono')
 
         iframe = AudioFrame('s16', 'stereo', 1024)
         iframe.sample_rate = 48000
@@ -53,7 +54,7 @@ class TestAudioResampler(TestCase):
 
     def test_pts_assertion_new_rate(self):
 
-        resampler = av.AudioResampler('s16', 'mono', 44100)
+        resampler = AudioResampler('s16', 'mono', 44100)
 
         iframe = AudioFrame('s16', 'stereo', 1024)
         iframe.sample_rate = 48000
@@ -74,10 +75,9 @@ class TestAudioResampler(TestCase):
         self.assertEqual(str(oframe.time_base), '1/44100')
         self.assertEqual(oframe.sample_rate, 44100)
 
-
     def test_pts_missing_time_base(self):
 
-        resampler = av.AudioResampler('s16', 'mono', 44100)
+        resampler = AudioResampler('s16', 'mono', 44100)
 
         iframe = AudioFrame('s16', 'stereo', 1024)
         iframe.sample_rate = 48000
@@ -90,7 +90,7 @@ class TestAudioResampler(TestCase):
 
     def test_pts_complex_time_base(self):
 
-        resampler = av.AudioResampler('s16', 'mono', 44100)
+        resampler = AudioResampler('s16', 'mono', 44100)
 
         iframe = AudioFrame('s16', 'stereo', 1024)
         iframe.sample_rate = 48000

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,9 +1,7 @@
 import unittest
 
-from av.audio.format import AudioFormat
-from av.codec import Codec, codecs_available
+from av import AudioFormat, Codec, VideoFormat, codecs_available
 from av.codec.codec import UnknownCodecError
-from av.video.format import VideoFormat
 
 from .common import TestCase
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -4,7 +4,9 @@ import os
 import sys
 import unittest
 
-from .common import *
+import av
+
+from .common import TestCase
 
 # On Windows, Python 3.0 - 3.5 have issues handling unicode filenames.
 # Starting with Python 3.6 the situation is saner thanks to PEP 529:
@@ -22,4 +24,4 @@ class TestContainers(TestCase):
     @unittest.skipIf(broken_unicode, 'Unicode filename handling is broken')
     def test_unicode_filename(self):
 
-        container = av.open(self.sandboxed(u'¢∞§¶•ªº.mov'), 'w')
+        av.open(self.sandboxed(u'¢∞§¶•ªº.mov'), 'w')

--- a/tests/test_containerformat.py
+++ b/tests/test_containerformat.py
@@ -1,5 +1,6 @@
-from .common import *
-from av.format import ContainerFormat, formats_available
+from av import ContainerFormat, formats_available
+
+from .common import TestCase
 
 
 class TestContainerFormats(TestCase):

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -1,5 +1,6 @@
-from __future__ import print_function
-from .common import *
+import av
+
+from .common import TestCase, fate_suite
 
 
 class TestDecode(TestCase):
@@ -28,7 +29,6 @@ class TestDecode(TestCase):
 
         sample_count = 0
 
-        print(audio_stream.frames)
         for packet in container.demux(audio_stream):
             for frame in packet.decode():
                 sample_count += frame.samples

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -2,7 +2,7 @@ import warnings
 
 from av import deprecation
 
-from .common import *
+from .common import TestCase
 
 
 class TestDeprecations(TestCase):
@@ -30,10 +30,10 @@ class TestDeprecations(TestCase):
 
             new_value = 'foo'
             old_value = deprecation.renamed_attr('new_value')
-            
+
             def new_func(self, a, b):
                 return a + b
-                
+
             old_func = deprecation.renamed_attr('new_func')
 
         obj = Example()
@@ -45,7 +45,6 @@ class TestDeprecations(TestCase):
 
             obj.old_value = 'bar'
             self.assertIn('Example.old_value is deprecated', captured[1].message.args[0])
-
 
         with warnings.catch_warnings(record=True) as captured:
             self.assertEqual(obj.old_func(1, 2), 3)

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -1,6 +1,6 @@
-from .common import *
-
 from av.dictionary import Dictionary
+
+from .common import TestCase
 
 
 class TestDictionary(TestCase):

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -1,16 +1,11 @@
-from __future__ import print_function
-
-from unittest import TestCase
 import doctest
-import os
-import re
-import sys
 import pkgutil
+import re
+from unittest import TestCase
 
 import av
 
 from .common import is_py3
-
 
 try:
     basestring
@@ -44,9 +39,7 @@ def register_doctests(mod):
         mod = __import__(mod, fromlist=[''])
     try:
         suite = doctest.DocTestSuite(mod)
-    except ValueError as e:
-        if e.args[-1] != 'has no docstrings':
-            print('test_doctest load error:', e, file=sys.__stdout__)
+    except ValueError:
         return
 
     fix_doctests(suite)
@@ -55,7 +48,8 @@ def register_doctests(mod):
     cls = type(cls_name, (TestCase, ), {})
 
     for test in suite._tests:
-        func = lambda self: test.runTest()
+        def func(self):
+            return test.runTest()
         name = str('test_' + re.sub('[^a-zA-Z0-9]+', '_', test.id()).strip('_'))
         func.__name__ = name
         setattr(cls, name, func)

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -1,16 +1,20 @@
 from __future__ import division
 
 import math
+from fractions import Fraction
+from unittest import SkipTest
 
-from .common import *
-
-from av.video.stream import VideoStream
+import av
+from av import AudioFrame, VideoFrame
 from av.audio.stream import AudioStream
+from av.video.stream import VideoStream
 
+from .common import Image, TestCase, fate_suite
 
 WIDTH = 320
 HEIGHT = 240
 DURATION = 48
+
 
 def write_rgb_rotate(output):
 
@@ -47,7 +51,6 @@ def write_rgb_rotate(output):
 
 def assert_rgb_rotate(self, input_):
 
-
     # Now inspect it a little.
     self.assertEqual(len(input_.streams), 1)
     self.assertEqual(input_.metadata.get('title'), 'container', input_.metadata)
@@ -56,7 +59,7 @@ def assert_rgb_rotate(self, input_):
     self.assertIsInstance(stream, VideoStream)
     self.assertEqual(stream.type, 'video')
     self.assertEqual(stream.name, 'mpeg4')
-    self.assertEqual(stream.average_rate, 24) # Only because we constructed is precisely.
+    self.assertEqual(stream.average_rate, 24)  # Only because we constructed is precisely.
     self.assertEqual(stream.rate, Fraction(24, 1))
     self.assertEqual(stream.time_base * stream.duration, 2)
     self.assertEqual(stream.format.name, 'yuv420p')
@@ -120,6 +123,7 @@ class TestBasicAudioEncoding(TestCase):
         ctx.time_base = sample_rate
         ctx.sample_rate = sample_rate
         ctx.format = sample_fmt
+        ctx.layout = channel_layout
         ctx.channels = channels
 
         src = av.open(fate_suite('audio-reference/chorusnoise_2ch_44kHz_s16.wav'))

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,9 +1,8 @@
 import pickle
 
-from .common import *
+from av.enums import EnumType, define_enum
 
-from av.enums import *
-
+from .common import TestCase
 
 # This must be at the top-level.
 PickleableFooBar = define_enum('PickleableFooBar', [('FOO', 1)])
@@ -51,7 +50,6 @@ class TestEnums(TestCase):
         self.assertEqual(cls.get('FOO'), foo1)
         self.assertIs(cls.get('not a foo'), None)
 
-
     def test_casting(self):
 
         cls = self.define_foobar()
@@ -66,7 +64,6 @@ class TestEnums(TestCase):
         int_foo = int(foo)
         self.assertIsInstance(int_foo, int)
         self.assertEqual(int_foo, 1)
-
 
     def test_iteration(self):
         cls = self.define_foobar()
@@ -105,7 +102,6 @@ class TestEnums(TestCase):
         foo = cls.FOO
 
         enc = pickle.dumps(foo)
-        print(enc)
 
         foo2 = pickle.loads(enc)
 
@@ -131,7 +127,7 @@ class TestEnums(TestCase):
         self.assertIs(cls.F, cls.FOO)
 
         self.assertEqual(cls.F.name, 'FOO')
-        self.assertNotEqual(cls.F.name, 'F') # This is actually the string.
+        self.assertNotEqual(cls.F.name, 'F')  # This is actually the string.
 
         self.assertEqual(cls.F, 'FOO')
         self.assertEqual(cls.F, 'F')
@@ -181,7 +177,7 @@ class TestEnums(TestCase):
 
         self.assertRaises(KeyError, lambda: cls['FOO|BAR'])
 
-        self.assertEqual(len(cls), 2) # It didn't get bigger
+        self.assertEqual(len(cls), 2)  # It didn't get bigger
         self.assertEqual(list(cls), [foo, bar])
 
     def test_multi_flags_create_missing(self):
@@ -191,5 +187,5 @@ class TestEnums(TestCase):
         foobar = cls[3]
         self.assertIs(foobar, cls.FOO | cls.BAR)
 
-        self.assertRaises(KeyError, lambda: cls[4]) # Not FOO or BAR
-        self.assertRaises(KeyError, lambda: cls[7]) # FOO and BAR and missing flag.
+        self.assertRaises(KeyError, lambda: cls[4])  # Not FOO or BAR
+        self.assertRaises(KeyError, lambda: cls[7])  # FOO and BAR and missing flag.

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,4 +1,7 @@
-from .common import *
+import av
+from av import AVError
+
+from .common import TestCase, is_windows
 
 
 class TestErrorBasics(TestCase):

--- a/tests/test_file_probing.py
+++ b/tests/test_file_probing.py
@@ -1,9 +1,10 @@
 from __future__ import division
 
 from fractions import Fraction
-import sys
 
-from .common import fate_suite, av, TestCase
+import av
+
+from .common import TestCase, fate_suite
 
 try:
     long

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,7 +1,9 @@
-from .common import *
+from unittest import SkipTest
 
-from av.video.frame import VideoFrame
-from av.filter import Graph, Filter
+from av import VideoFrame
+from av.filter import Filter, Graph
+
+from .common import Image, TestCase, fate_suite
 
 
 class TestFilters(TestCase):
@@ -63,8 +65,6 @@ class TestFilters(TestCase):
         src = graph.add('testsrc')
         src.link_to(graph.add('buffersink'))
         graph.configure()
-
-        print(src.outputs)
 
         frame = src.pull()
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,12 +1,13 @@
 from __future__ import division
 
-from .common import *
-
 import logging
 import threading
 
 import av.logging
 import av.utils
+from av import AVError
+
+from .common import TestCase
 
 
 def do_log(message):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,13 +1,14 @@
-from .common import *
-
+from av import ContainerFormat
 from av.option import Option, OptionType
+
+from .common import TestCase
 
 
 class TestOptions(TestCase):
 
     def test_mov_options(self):
 
-        mov = av.ContainerFormat('mov')
+        mov = ContainerFormat('mov')
         options = mov.descriptor.options
         by_name = {opt.name: opt for opt in options}
 

--- a/tests/test_python_io.py
+++ b/tests/test_python_io.py
@@ -1,14 +1,14 @@
 from __future__ import division
 
-import math
+import av
+
+from .common import MethodLogger, TestCase, fate_suite
+from .test_encode import assert_rgb_rotate, write_rgb_rotate
+
 try:
     from cStringIO import StringIO
 except ImportError:
     from io import BytesIO as StringIO
-
-from .common import *
-from .test_encode import write_rgb_rotate, assert_rgb_rotate
-from av.video.stream import VideoStream
 
 
 class NonSeekableBuffer:
@@ -52,7 +52,6 @@ class TestPythonIO(TestCase):
         self.assertEqual(container.format.name, 'mpegts')
         self.assertEqual(container.format.long_name, "MPEG-TS (MPEG-2 Transport Stream)")
         self.assertEqual(len(container.streams), 1)
-        #self.assertEqual(container.size, 800000)
         self.assertEqual(container.metadata, {})
 
         # Make sure it did actually call "read".

--- a/tests/test_seek.py
+++ b/tests/test_seek.py
@@ -1,11 +1,11 @@
 from __future__ import division
 
-import math
+import unittest
 
-from .common import *
-
-from av.packet import Packet
+import av
 from av import time_base as AV_TIME_BASE
+
+from .common import TestCase, fate_suite
 
 
 def timestamp_to_frame(timestamp, stream):
@@ -68,7 +68,6 @@ class TestSeek(TestCase):
         seek_packet_count = 0
         for packet in container.demux():
             seek_packet_count += 1
-
 
         self.assertTrue(seek_packet_count < total_packet_count)
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,4 +1,6 @@
-from .common import *
+import av
+
+from .common import TestCase, fate_suite
 
 
 class TestStreams(TestCase):
@@ -19,8 +21,8 @@ class TestStreams(TestCase):
 
         container = av.open(fate_suite('h264/interlaced_crop.mp4'))
         video = container.streams.video[0]
-        #audio_stream = container.streams.audio[0]
-        #audio_streams = list(container.streams.audio[0:2])
+        # audio_stream = container.streams.audio[0]
+        # audio_streams = list(container.streams.audio[0:2])
 
         self.assertEqual([video], container.streams.get(video=0))
         self.assertEqual([video], container.streams.get(video=(0, )))

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -1,8 +1,7 @@
-import sys
+import av
+from av.subtitles.subtitle import AssSubtitle, BitmapSubtitle
 
-from .common import *
-
-from av.subtitles.subtitle import *
+from .common import TestCase, fate_suite
 
 
 class TestSubtitle(TestCase):
@@ -44,6 +43,6 @@ class TestSubtitle(TestCase):
         bms = sub.planes
         self.assertEqual(len(bms), 1)
         if hasattr(__builtins__, 'buffer'):
-            self.assertEqual(len(buffer(bms[0])), 4800)
+            self.assertEqual(len(buffer(bms[0])), 4800)  # noqa
         if hasattr(__builtins__, 'memoryview'):
-            self.assertEqual(len(memoryview(bms[0])), 4800)
+            self.assertEqual(len(memoryview(bms[0])), 4800)  # noqa

--- a/tests/test_videoformat.py
+++ b/tests/test_videoformat.py
@@ -1,6 +1,6 @@
-from .common import *
+from av import VideoFormat
 
-from av.video.format import VideoFormat
+from .common import TestCase
 
 
 class TestVideoFormats(TestCase):


### PR DESCRIPTION
- we don't need nose's SkipTest, unittest's is fine since Python 2.7
- remove print statements
- eliminate star imports
- run flake8 and isort on examples and tests