### PR TITLE
Codec parsing

### DIFF
--- a/av/codec/context.pxd
+++ b/av/codec/context.pxd
@@ -21,10 +21,6 @@ cdef class CodecContext(object):
     cdef int stream_index
 
     cdef lib.AVCodecParserContext *parser
-    cdef unsigned char *parse_buffer
-    cdef size_t parse_buffer_size
-    cdef size_t parse_buffer_max_size
-    cdef size_t parse_pos
 
     # To hold a reference to passed extradata.
     cdef ByteSource extradata_source

--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -167,7 +167,7 @@ cdef class CodecContext(object):
         )
 
     def parse(self, raw_input=None):
-        """Split up a byte shttps://github.com/mikeboers/PyAV/pull/472tream into list of :class:`.Packet`.
+        """Split up a byte stream into list of :class:`.Packet`.
 
         This is only effectively splitting up a byte stream, and does no
         actual interpretation of the data.

--- a/docs/cookbook/basics.rst
+++ b/docs/cookbook/basics.rst
@@ -20,6 +20,14 @@ Remuxing is copying audio/video data from one container to the other without tra
 .. literalinclude:: ../../examples/basics/remux.py
 
 
+Parsing
+-------
+
+Sometimes we have a raw stream of data, and we need to split it into packets before working with it. We can use :meth:`.CodecContext.parse` to do this.
+
+.. literalinclude:: ../../examples/basics/parse.py
+
+
 Threading
 ---------
 

--- a/examples/basics/parse.py
+++ b/examples/basics/parse.py
@@ -9,10 +9,11 @@ import av.datasets
 # We haven't exposed bitstream filters yet, so we're gonna use the `ffmpeg` CLI.
 h264_path = 'night-sky.h264'
 if not os.path.exists(h264_path):
-    subprocess.check_call(['ffmpeg',
+    subprocess.check_call([
+        'ffmpeg',
         '-i', av.datasets.curated('pexels/time-lapse-video-of-night-sky-857195.mp4'),
-        '-vcodec', 'copy', 
-        '-an', 
+        '-vcodec', 'copy',
+        '-an',
         '-bsf:v', 'h264_mp4toannexb',
         h264_path,
     ])

--- a/examples/basics/parse.py
+++ b/examples/basics/parse.py
@@ -1,0 +1,43 @@
+import os
+import subprocess
+
+import av
+import av.datasets
+
+
+# We want an H.264 stream in the Annex B byte-stream format.
+# We haven't exposed bitstream filters yet, so we're gonna use the `ffmpeg` CLI.
+h264_path = 'night-sky.h264'
+if not os.path.exists(h264_path):
+    subprocess.check_call(['ffmpeg',
+        '-i', av.datasets.curated('pexels/time-lapse-video-of-night-sky-857195.mp4'),
+        '-vcodec', 'copy', 
+        '-an', 
+        '-bsf:v', 'h264_mp4toannexb',
+        h264_path,
+    ])
+
+
+fh = open(h264_path, 'rb')
+
+codec = av.CodecContext.create('h264', 'r')
+
+while True:
+
+    chunk = fh.read(1 << 16)
+
+    packets = codec.parse(chunk)
+    print("Parsed {} packets from {} bytes:".format(len(packets), len(chunk)))
+
+    for packet in packets:
+
+        print('   ', packet)
+
+        frames = codec.decode(packet)
+        for frame in frames:
+            print('       ', frame)
+
+    # We wait until the end to bail so that the last empty `buf` flushes
+    # the parser.
+    if not chunk:
+        break

--- a/tests/test_codec_context.py
+++ b/tests/test_codec_context.py
@@ -43,6 +43,37 @@ class TestCodecContext(TestCase):
         ctx = Codec('png', 'w').create()
         self.assertEqual(ctx.skip_frame.name, 'DEFAULT')
 
+    def test_parse(self):
+
+        # This one parses into a single packet.
+        self._assert_parse('mpeg4', fate_suite('h264/interlaced_crop.mp4'))
+
+        # This one parses into many small packets.
+        self._assert_parse('mpeg2video', fate_suite('mpeg2/mpeg2_field_encoding.ts'))
+
+    def _assert_parse(self, codec_name, path):
+
+        fh = av.open(path)
+        packets = []
+        for packet in fh.demux(video=0):
+            packets.append(packet)
+
+        full_source = b''.join(p.to_bytes() for p in packets)
+
+        for size in 1024, 8192, 65535:
+
+            ctx = Codec(codec_name).create()
+            packets = []
+
+            for i in range(0, len(full_source), size):
+                block = full_source[i:i + size]
+                packets.extend(ctx.parse(block))
+            packets.extend(ctx.parse())
+
+            parsed_source = b''.join(p.to_bytes() for p in packets)
+            self.assertEqual(len(parsed_source), len(full_source))
+            self.assertEqual(full_source, parsed_source)
+
 
 class TestEncoding(TestCase):
 


### PR DESCRIPTION
Another option is to create a separate `CodecParser` object. While that feels more flexible, etc., when would someone really want to have the parser in isolation from the context?

I'll answer my own question: when someone doesn't care to decode at the moment.

I'm going to go isolate it.