### PR TITLE
Decode reuse Frame Object

### DIFF
--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -89,7 +89,8 @@ cdef class AudioFrame(Frame):
     cdef _init_user_attributes(self):
         self.layout = get_audio_layout(0, self.ptr.channel_layout)
         self.format = get_audio_format(<lib.AVSampleFormat>self.ptr.format)
-        self._init_planes(AudioPlane)
+        if self.planes is None:
+            self._init_planes(AudioPlane)
 
     def __repr__(self):
         return '<av.%s %d, pts=%s, %d samples at %dHz, %s, %s at 0x%x>' % (

--- a/av/codec/context.pxd
+++ b/av/codec/context.pxd
@@ -43,7 +43,7 @@ cdef class CodecContext(object):
 
     # Wraps both versions of the transcode API, returning lists.
     cpdef encode(self, Frame frame=?)
-    cpdef decode(self, Packet packet=?)
+    cpdef decode(self, Packet packet=?, bint reuse = ?)
 
     # Used by both transcode APIs to setup user-land objects.
     # TODO: Remove the `Packet` from `_setup_decoded_frame` (because flushing
@@ -60,13 +60,13 @@ cdef class CodecContext(object):
     # the buffer as often as possible.
     cdef _send_frame_and_recv(self, Frame frame)
     cdef _recv_packet(self)
-    cdef _send_packet_and_recv(self, Packet packet)
+    cdef _send_packet_and_recv(self, Packet packet, bint reuse = ?)
     cdef _recv_frame(self)
 
     # Implemented by children for the generic send/recv API, so we have the
     # correct subclass of Frame.
     cdef Frame _next_frame
     cdef Frame _alloc_next_frame(self)
-
+    cdef Frame _save_frame
 
 cdef CodecContext wrap_codec_context(lib.AVCodecContext*, const lib.AVCodec*, bint allocated)

--- a/av/frame.pyx
+++ b/av/frame.pyx
@@ -39,6 +39,7 @@ cdef class Frame(object):
         # ourselves to the maximum plane count (as determined only by VideoFrames
         # so far), in case the library implementation does not set the last
         # plane to NULL.
+
         cdef int max_plane_count = self._max_plane_count()
         cdef int plane_count = 0
         while plane_count < max_plane_count and self.ptr.extended_data[plane_count]:

--- a/av/packet.pyx
+++ b/av/packet.pyx
@@ -204,6 +204,9 @@ cdef class Packet(Buffer):
             if self.struct.duration != lib.AV_NOPTS_VALUE:
                 return self.struct.duration
 
+    property flags:
+        def __get__(self): return self.struct.flags
+
     property is_keyframe:
         def __get__(self): return bool(self.struct.flags & lib.AV_PKT_FLAG_KEY)
 

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -183,6 +183,10 @@ cdef class Stream(object):
             else:
                 return None
 
+    property level:
+        def __get__(self):
+            return self._codec_context.level
+
     property index:
         """
         The index of this stream in its :class:`.Container`.

--- a/av/subtitles/codeccontext.pyx
+++ b/av/subtitles/codeccontext.pyx
@@ -8,7 +8,7 @@ from av.utils cimport err_check
 
 cdef class SubtitleCodecContext(CodecContext):
 
-    cdef _send_packet_and_recv(self, Packet packet):
+    cdef _send_packet_and_recv(self, Packet packet, bint reuse = False):
         cdef SubtitleProxy proxy = SubtitleProxy()
 
         cdef int got_frame = 0

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -96,7 +96,8 @@ cdef class VideoFrame(Frame):
 
     cdef _init_user_attributes(self):
         self.format = get_video_format(<lib.AVPixelFormat>self.ptr.format, self.ptr.width, self.ptr.height)
-        self._init_planes(VideoPlane)
+        if self.planes is None:
+            self._init_planes(VideoPlane)
 
     def __dealloc__(self):
         # The `self._buffer` member is only set if *we* allocated the buffer in `_init`,

--- a/include/libavcodec/avcodec.pxd
+++ b/include/libavcodec/avcodec.pxd
@@ -120,6 +120,7 @@ cdef extern from "libavcodec/avcodec.pyav.h" nogil:
         int thread_type
 
         int profile
+        int level
         AVDiscard skip_frame
 
         AVFrame* coded_frame


### PR DESCRIPTION
add options for Decode reuse Frame Object, prevent python GC using large of memory.

Usage: 
```
import av

in_container = av.open(file="test.flv", format='flv')

for packet in in_container.demux():
	if packet.stream.type == "video":
		for frame in packet.stream.codec_context.decode(packet, reuse=True):
			print(frame, frame.format)
	
	if packet.stream.type == "audio":
		for frame in packet.stream.codec_context.decode(packet, reuse=True):
			print(frame, frame.format)
```