### PR TITLE
add xdecode for reuse Frame object

### DIFF
--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -89,7 +89,8 @@ cdef class AudioFrame(Frame):
     cdef _init_user_attributes(self):
         self.layout = get_audio_layout(0, self.ptr.channel_layout)
         self.format = get_audio_format(<lib.AVSampleFormat>self.ptr.format)
-        self._init_planes(AudioPlane)
+        if self.planes is None:
+            self._init_planes(AudioPlane)
 
     def __repr__(self):
         return '<av.%s %d, pts=%s, %d samples at %dHz, %s, %s at 0x%x>' % (

--- a/av/container/input.pyx
+++ b/av/container/input.pyx
@@ -163,6 +163,23 @@ cdef class InputContainer(Container):
             for frame in packet.decode():
                 yield frame
 
+    def xdecode(self, *args, **kwargs):
+        """xdecode(streams=None, video=None, audio=None, subtitles=None, data=None)
+
+        Yields a series of :class:`.Frame` from the given set of streams::
+
+            for frame in container.decode():
+                # Do something with `frame`.
+
+        .. seealso:: :meth:`.StreamContainer.get` for the interpretation of
+            the arguments.
+
+        """
+        id(kwargs) # Avoid Cython bug; see demux().
+        for packet in self.demux(*args, **kwargs):
+            for frame in packet.xdecode():
+                yield frame
+
     def seek(self, offset, whence='time', backward=True, any_frame=False, stream=None):
         """Seek to a (key)frame nearsest to the given timestamp.
 

--- a/av/packet.pyx
+++ b/av/packet.pyx
@@ -101,6 +101,13 @@ cdef class Packet(Buffer):
         """
         return self._stream.decode(self)
 
+    def xdecode(self):
+        """
+        Send the packet's data to the decoder and return a list of
+        :class:`.AudioFrame`, :class:`.VideoFrame` or :class:`.SubtitleSet`.
+        """
+        return self._stream.xdecode(self)
+
     @deprecation.method
     def decode_one(self):
         """

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -144,6 +144,13 @@ cdef class Stream(object):
         """
         return self.codec_context.decode(packet)
 
+    def xdecode(self, packet=None):
+        """
+        Decode a :class:`.Packet` and return a list of :class:`.AudioFrame`
+        or :class:`.VideoFrame`.
+        """
+        return self.codec_context.xdecode(packet)
+
     @deprecation.method
     def seek(self, offset, whence='time', backward=True, any_frame=False):
         """

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -96,7 +96,8 @@ cdef class VideoFrame(Frame):
 
     cdef _init_user_attributes(self):
         self.format = get_video_format(<lib.AVPixelFormat>self.ptr.format, self.ptr.width, self.ptr.height)
-        self._init_planes(VideoPlane)
+        if self.planes is None:
+            self._init_planes(VideoPlane)
 
     def __dealloc__(self):
         # The `self._buffer` member is only set if *we* allocated the buffer in `_init`,


### PR DESCRIPTION
add xdecode function for decoding to reuse Frame Object, prevent python GC using large of memory.

demo:
```
import av

in_container = av.open(file="test.flv", format='flv')

for packet in in_container.demux():
	if packet.stream.type == "video":
		for frame in packet.stream.codec_context.xdecode(packet):
			print(frame, frame.format)
	elif packet.stream.type == "audio":
		for frame in packet.stream.codec_context.xdecode(packet):
			print(frame, frame.format)
```