### PR TITLE
Add support r_rate from ffmpeg r_frame_rate

### DIFF
--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -211,6 +211,15 @@ cdef class Stream(object):
         def __get__(self):
             return avrational_to_fraction(&self._stream.avg_frame_rate)
 
+    property r_rate:
+        """
+        The Real base framerate of this stream.
+
+        :type: fractions.Fraction
+        """
+        def __get__(self):
+            return avrational_to_fraction(&self._stream.r_frame_rate)
+        
     property start_time:
         """
         The presentation timestamp in :attr:`time_base` units of the first

--- a/include/libavformat/avformat.pxd
+++ b/include/libavformat/avformat.pxd
@@ -44,6 +44,7 @@ cdef extern from "libavformat/avformat.h" nogil:
         AVDictionary *metadata
 
         AVRational avg_frame_rate
+        AVRational r_frame_rate
         AVRational sample_aspect_ratio
 
     # http://ffmpeg.org/doxygen/trunk/structAVIOContext.html

--- a/tests/test_file_probing.py
+++ b/tests/test_file_probing.py
@@ -34,6 +34,7 @@ class TestAudioProbe(TestCase):
 
         # actual stream properties
         self.assertEqual(stream.average_rate, None)
+        self.assertEqual(stream.r_rate, None)
         self.assertEqual(stream.duration, 554880)
         self.assertEqual(stream.frames, 0)
         self.assertEqual(stream.id, 256)
@@ -95,6 +96,7 @@ class TestDataProbe(TestCase):
 
         # actual stream properties
         self.assertEqual(stream.average_rate, None)
+        self.assertEqual(stream.r_rate, None)
         self.assertEqual(stream.duration, 37537)
         self.assertEqual(stream.frames, 0)
         self.assertEqual(stream.id, 1)


### PR DESCRIPTION
Hi Thank you great library!!

I am creating a tool to excel metadata with PyAV.

Current PyAV can refer to avg_frame_rate.
However, when displayed with avg_frame_rate, it shows a value different from popular players.
What I confirmed are Mac's QT player, VLC, djv, mediainfo.

Another problem.
When trying to display "TC" by passing avg_frame_rate to the TimeCode library, it tends to be a strange value and it is difficult to use.

For the above two reasons, I think it would be more convenient to make it possible to access r_frame_rate with PyAV.

#319 may be somewhat related(reason is different from me)