### PR TITLE
Remove ContainerProxy.

### DIFF
--- a/av/container/core.pxd
+++ b/av/container/core.pxd
@@ -5,24 +5,18 @@ from av.dictionary cimport _Dictionary
 from av.format cimport ContainerFormat
 from av.stream cimport Stream
 
-# Since there are multiple objects that need to refer to a valid context, we
-# need this intermediate proxy object so that there aren't any reference cycles
-# and the pointer can be freed when everything that depends upon it is deleted.
-cdef class ContainerProxy(object):
 
-    cdef bint writeable
+cdef class Container(object):
+
+    cdef readonly bint writeable
     cdef lib.AVFormatContext *ptr
 
-    cdef seek(self, int stream_index, offset, str whence, bint backward, bint any_frame)
-    cdef flush_buffers(self)
-
-    # Copies from Container.
-    cdef object name
-    cdef str metadata_encoding
-    cdef str metadata_errors
+    cdef readonly object name
+    cdef readonly str metadata_encoding
+    cdef readonly str metadata_errors
 
     # File-like source.
-    cdef object file
+    cdef readonly object file
     cdef object fread
     cdef object fwrite
     cdef object fseek
@@ -36,27 +30,13 @@ cdef class ContainerProxy(object):
     cdef bint pos_is_valid
     cdef bint input_was_opened
 
-    cdef int err_check(self, int value) except -1
-
-
-cdef class Container(object):
-
-    cdef readonly object name
-    cdef readonly object file
-
-    cdef readonly bint writeable
-
     cdef readonly ContainerFormat format
 
     cdef readonly dict options
     cdef readonly dict container_options
     cdef readonly list stream_options
 
-    cdef ContainerProxy proxy
-    cdef object __weakref__
-
     cdef readonly StreamContainer streams
     cdef readonly dict metadata
 
-    cdef readonly str metadata_encoding
-    cdef readonly str metadata_errors
+    cdef int err_check(self, int value) except -1

--- a/av/container/core.pyx
+++ b/av/container/core.pyx
@@ -30,22 +30,37 @@ ctypedef int64_t (*seek_func_t)(void *opaque, int64_t offset, int whence) nogil
 cdef object _cinit_sentinel = object()
 
 
-cdef class ContainerProxy(object):
+cdef class Container(object):
 
-    def __init__(self, sentinel, Container container):
+    def __cinit__(self, sentinel, file_, format_name, options, container_options, stream_options, metadata_encoding, metadata_errors):
+
+        if sentinel is not _cinit_sentinel:
+            raise RuntimeError('cannot construct base Container')
+
+        self.writeable = isinstance(self, OutputContainer)
+        if not self.writeable and not isinstance(self, InputContainer):
+            raise RuntimeError('Container cannot be directly extended.')
+
+        if isinstance(file_, basestring):
+            self.name = file_
+        else:
+            self.name = getattr(file_, 'name', '<none>')
+            if not isinstance(self.name, basestring):
+                raise TypeError("File's name attribute must be string-like.")
+            self.file = file_
+
+        self.options = dict(options or ())
+        self.container_options = dict(container_options or ())
+        self.stream_options = [dict(x) for x in stream_options or ()]
+
+        self.metadata_encoding = metadata_encoding
+        self.metadata_errors = metadata_errors
+
+        if format_name is not None:
+            self.format = ContainerFormat(format_name)
 
         self.input_was_opened = False
         cdef int res
-
-        if sentinel is not _cinit_sentinel:
-            raise RuntimeError('cannot construct ContainerProxy')
-
-        # Copy key attributes.
-        self.file = container.file
-        self.metadata_encoding = container.metadata_encoding
-        self.metadata_errors = container.metadata_errors
-        self.name = container.name
-        self.writeable = container.writeable
 
         cdef bytes name_obj = fsencode(self.name) if isinstance(self.name, unicode) else self.name
         cdef char *name = name_obj
@@ -54,7 +69,7 @@ cdef class ContainerProxy(object):
         cdef lib.AVOutputFormat *ofmt
         if self.writeable:
 
-            ofmt = container.format.optr if container.format else lib.av_guess_format(NULL, name, NULL)
+            ofmt = self.format.optr if self.format else lib.av_guess_format(NULL, name, NULL)
             if ofmt == NULL:
                 raise ValueError("Could not determine output format")
 
@@ -115,22 +130,27 @@ cdef class ContainerProxy(object):
             self.ptr.pb = self.iocontext
 
         cdef lib.AVInputFormat *ifmt
-        cdef _Dictionary options
+        cdef _Dictionary c_options
         if not self.writeable:
-            ifmt = container.format.iptr if container.format else NULL
 
-            options = Dictionary(container.options, container.container_options)
+            ifmt = self.format.iptr if self.format else NULL
+
+            c_options = Dictionary(self.options, self.container_options)
             with nogil:
                 res = lib.avformat_open_input(
                     &self.ptr,
                     name,
                     ifmt,
-                    &options.ptr
+                    &c_options.ptr
                 )
             self.err_check(res)
             self.input_was_opened = True
 
+        if format_name is None:
+            self.format = build_container_format(self.ptr.iformat, self.ptr.oformat)
+
     def __dealloc__(self):
+
         with nogil:
 
             # Let FFmpeg close input if it was fully opened.
@@ -151,89 +171,15 @@ cdef class ContainerProxy(object):
             # Finish releasing the whole structure.
             lib.avformat_free_context(self.ptr)
 
-    cdef seek(self, int stream_index, offset, str whence, bint backward, bint any_frame):
-
-        # We used to take floats here and assume they were in seconds. This
-        # was super confusing, so lets go in the complete opposite direction.
-        if not isinstance(offset, (int, long)):
-            raise TypeError('Container.seek only accepts integer offset.', type(offset))
-        cdef int64_t c_offset = offset
-
-        cdef int flags = 0
-        cdef int ret
-
-        if whence == 'frame':
-            flags |= lib.AVSEEK_FLAG_FRAME
-        elif whence == 'byte':
-            flags |= lib.AVSEEK_FLAG_BYTE
-        elif whence != 'time':
-            raise ValueError("whence must be one of 'frame', 'byte', or 'time'.", whence)
-
-        if backward:
-            flags |= lib.AVSEEK_FLAG_BACKWARD
-
-        if any_frame:
-            flags |= lib.AVSEEK_FLAG_ANY
-
-        with nogil:
-            ret = lib.av_seek_frame(self.ptr, stream_index, c_offset, flags)
-        err_check(ret)
-
-        self.flush_buffers()
-
-    cdef flush_buffers(self):
-        cdef unsigned int i
-        cdef lib.AVStream *stream
-
-        with nogil:
-            for i in range(self.ptr.nb_streams):
-                stream = self.ptr.streams[i]
-                if stream.codec and stream.codec.codec and stream.codec.codec_id != lib.AV_CODEC_ID_NONE:
-                    lib.avcodec_flush_buffers(stream.codec)
+    def __repr__(self):
+        return '<av.%s %r>' % (self.__class__.__name__, self.file or self.name)
 
     cdef int err_check(self, int value) except -1:
         return err_check(value, filename=self.name)
 
-
-cdef class Container(object):
-
-    def __cinit__(self, sentinel, file_, format_name, options, container_options, stream_options, metadata_encoding, metadata_errors):
-
-        if sentinel is not _cinit_sentinel:
-            raise RuntimeError('cannot construct base Container')
-
-        self.writeable = isinstance(self, OutputContainer)
-        if not self.writeable and not isinstance(self, InputContainer):
-            raise RuntimeError('Container cannot be extended except')
-
-        if isinstance(file_, basestring):
-            self.name = file_
-        else:
-            self.name = getattr(file_, 'name', '<none>')
-            if not isinstance(self.name, basestring):
-                raise TypeError("File's name attribute must be string-like.")
-            self.file = file_
-
-        if format_name is not None:
-            self.format = ContainerFormat(format_name)
-
-        self.options = dict(options or ())
-        self.container_options = dict(container_options or ())
-        self.stream_options = [dict(x) for x in stream_options or ()]
-
-        self.metadata_encoding = metadata_encoding
-        self.metadata_errors = metadata_errors
-        self.proxy = ContainerProxy(_cinit_sentinel, self)
-
-        if format_name is None:
-            self.format = build_container_format(self.proxy.ptr.iformat, self.proxy.ptr.oformat)
-
-    def __repr__(self):
-        return '<av.%s %r>' % (self.__class__.__name__, self.file or self.name)
-
     def dumps_format(self):
         with LogCapture() as logs:
-            lib.av_dump_format(self.proxy.ptr, 0, "", isinstance(self, OutputContainer))
+            lib.av_dump_format(self.ptr, 0, "", isinstance(self, OutputContainer))
         return ''.join(log[2] for log in logs)
 
 

--- a/av/container/input.pxd
+++ b/av/container/input.pxd
@@ -5,4 +5,5 @@ from av.stream cimport Stream
 
 
 cdef class InputContainer(Container):
-    pass
+
+    cdef flush_buffers(self)

--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -56,7 +56,7 @@ cdef class OutputContainer(Container):
 
         # Assert that this format supports the requested codec.
         if not lib.avformat_query_codec(
-            self.proxy.ptr.oformat,
+            self.ptr.oformat,
             codec.id,
             lib.FF_COMPLIANCE_NORMAL,
         ):
@@ -66,8 +66,8 @@ cdef class OutputContainer(Container):
         # As of last check, avformat_new_stream only calls avcodec_alloc_context3 to create
         # the context, but doesn't modify it in any other way. Ergo, we can allow CodecContext
         # to finish initializing it.
-        lib.avformat_new_stream(self.proxy.ptr, codec)
-        cdef lib.AVStream *stream = self.proxy.ptr.streams[self.proxy.ptr.nb_streams - 1]
+        lib.avformat_new_stream(self.ptr, codec)
+        cdef lib.AVStream *stream = self.ptr.streams[self.ptr.nb_streams - 1]
         cdef lib.AVCodecContext *codec_context = stream.codec  # For readability.
 
         # Copy from the template.
@@ -102,7 +102,7 @@ cdef class OutputContainer(Container):
             codec_context.channel_layout = lib.AV_CH_LAYOUT_STEREO
 
         # Some formats want stream headers to be separate
-        if self.proxy.ptr.oformat.flags & lib.AVFMT_GLOBALHEADER:
+        if self.ptr.oformat.flags & lib.AVFMT_GLOBALHEADER:
             codec_context.flags |= lib.AV_CODEC_FLAG_GLOBAL_HEADER
 
         # Construct the user-land stream
@@ -146,18 +146,18 @@ cdef class OutputContainer(Container):
             stream._finalize_for_output()
 
         # Open the output file, if needed.
-        cdef char *name = "" if self.proxy.file is not None else self.name
-        if self.proxy.ptr.pb == NULL and not self.proxy.ptr.oformat.flags & lib.AVFMT_NOFILE:
-            err_check(lib.avio_open(&self.proxy.ptr.pb, name, lib.AVIO_FLAG_WRITE))
+        cdef char *name = "" if self.file is not None else self.name
+        if self.ptr.pb == NULL and not self.ptr.oformat.flags & lib.AVFMT_NOFILE:
+            err_check(lib.avio_open(&self.ptr.pb, name, lib.AVIO_FLAG_WRITE))
 
         # Copy the metadata dict.
-        dict_to_avdict(&self.proxy.ptr.metadata, self.metadata, clear=True,
+        dict_to_avdict(&self.ptr.metadata, self.metadata, clear=True,
                        encoding=self.metadata_encoding, errors=self.metadata_errors)
 
         cdef _Dictionary all_options = Dictionary(self.options, self.container_options)
         cdef _Dictionary options = all_options.copy()
-        self.proxy.err_check(lib.avformat_write_header(
-            self.proxy.ptr,
+        self.err_check(lib.avformat_write_header(
+            self.ptr,
             &options.ptr
         ))
 
@@ -184,13 +184,13 @@ cdef class OutputContainer(Container):
                 raise ValueError("Encoding hasn't started.")
             return
 
-        self.proxy.err_check(lib.av_write_trailer(self.proxy.ptr))
+        self.err_check(lib.av_write_trailer(self.ptr))
         cdef Stream stream
         for stream in self.streams:
             stream.codec_context.close()
 
-        if self.file is None and not self.proxy.ptr.oformat.flags & lib.AVFMT_NOFILE:
-            lib.avio_closep(&self.proxy.ptr.pb)
+        if self.file is None and not self.ptr.oformat.flags & lib.AVFMT_NOFILE:
+            lib.avio_closep(&self.ptr.pb)
 
         self._done = True
 
@@ -208,18 +208,18 @@ cdef class OutputContainer(Container):
         self.start_encoding()
 
         # Assert the packet is in stream time.
-        if packet.struct.stream_index < 0 or <unsigned int>packet.struct.stream_index >= self.proxy.ptr.nb_streams:
+        if packet.struct.stream_index < 0 or <unsigned int>packet.struct.stream_index >= self.ptr.nb_streams:
             raise ValueError('Bad Packet stream_index.')
-        cdef lib.AVStream *stream = self.proxy.ptr.streams[packet.struct.stream_index]
+        cdef lib.AVStream *stream = self.ptr.streams[packet.struct.stream_index]
         packet._rebase_time(stream.time_base)
 
         # Make another reference to the packet, as av_interleaved_write_frame
         # takes ownership of it.
         cdef lib.AVPacket packet_ref
         lib.av_init_packet(&packet_ref)
-        self.proxy.err_check(lib.av_packet_ref(&packet_ref, &packet.struct))
+        self.err_check(lib.av_packet_ref(&packet_ref, &packet.struct))
 
         cdef int ret
         with nogil:
-            ret = lib.av_interleaved_write_frame(self.proxy.ptr, &packet_ref)
-        self.proxy.err_check(ret)
+            ret = lib.av_interleaved_write_frame(self.ptr, &packet_ref)
+        self.err_check(ret)

--- a/av/container/pyio.pyx
+++ b/av/container/pyio.pyx
@@ -2,7 +2,7 @@ from libc.string cimport memcpy
 
 cimport libav as lib
 
-from av.container.core cimport ContainerProxy
+from av.container.core cimport Container
 from av.utils cimport stash_exception
 
 
@@ -11,10 +11,10 @@ cdef int pyio_read(void *opaque, uint8_t *buf, int buf_size) nogil:
         return pyio_read_gil(opaque, buf, buf_size)
 
 cdef int pyio_read_gil(void *opaque, uint8_t *buf, int buf_size):
-    cdef ContainerProxy self
+    cdef Container self
     cdef bytes res
     try:
-        self = <ContainerProxy>opaque
+        self = <Container>opaque
         res = self.fread(buf_size)
         memcpy(buf, <void*><char*>res, len(res))
         self.pos += len(res)
@@ -30,11 +30,11 @@ cdef int pyio_write(void *opaque, uint8_t *buf, int buf_size) nogil:
         return pyio_write_gil(opaque, buf, buf_size)
 
 cdef int pyio_write_gil(void *opaque, uint8_t *buf, int buf_size):
-    cdef ContainerProxy self
+    cdef Container self
     cdef bytes bytes_to_write
     cdef int bytes_written
     try:
-        self = <ContainerProxy>opaque
+        self = <Container>opaque
         bytes_to_write = buf[:buf_size]
         ret_value = self.fwrite(bytes_to_write)
         bytes_written = ret_value if isinstance(ret_value, int) else buf_size
@@ -54,9 +54,9 @@ cdef int64_t pyio_seek(void *opaque, int64_t offset, int whence) nogil:
         return pyio_seek_gil(opaque, offset, whence)
 
 cdef int64_t pyio_seek_gil(void *opaque, int64_t offset, int whence):
-    cdef ContainerProxy self
+    cdef Container self
     try:
-        self = <ContainerProxy>opaque
+        self = <Container>opaque
         res = self.fseek(offset, whence)
 
         # Track the position for the user.

--- a/av/stream.pxd
+++ b/av/stream.pxd
@@ -3,7 +3,7 @@ from libc.stdint cimport int64_t
 cimport libav as lib
 
 from av.codec.context cimport CodecContext
-from av.container.core cimport Container, ContainerProxy
+from av.container.core cimport Container
 from av.frame cimport Frame
 from av.packet cimport Packet
 
@@ -11,8 +11,7 @@ from av.packet cimport Packet
 cdef class Stream(object):
 
     # Stream attributes.
-    cdef ContainerProxy _container
-    cdef _weak_container
+    cdef readonly Container container
 
     cdef lib.AVStream *_stream
     cdef readonly dict metadata
@@ -20,7 +19,6 @@ cdef class Stream(object):
     # CodecContext attributes.
     cdef lib.AVCodecContext *_codec_context
     cdef const lib.AVCodec *_codec
-    cdef lib.AVDictionary *_codec_options
 
     cdef readonly CodecContext codec_context
 

--- a/scratchpad/container-gc.py
+++ b/scratchpad/container-gc.py
@@ -1,0 +1,44 @@
+import resource
+import gc
+
+
+import av
+import av.datasets
+
+path = av.datasets.curated('pexels/time-lapse-video-of-night-sky-857195.mp4')
+
+
+def format_bytes(n):
+    order = 0
+    while n > 1024:
+        order += 1
+        n //= 1024
+    return '%d%sB' % (n, ('', 'k', 'M', 'G', 'T', 'P')[order])
+
+after = resource.getrusage(resource.RUSAGE_SELF)
+
+count = 0
+
+streams = []
+
+while True:
+
+    container = av.open(path)
+    # streams.append(container.streams.video[0])
+
+    del container
+    gc.collect()
+    
+    count += 1
+    if not count % 100:
+        pass
+        # streams.clear()
+        # gc.collect()
+
+    before = after
+    after = resource.getrusage(resource.RUSAGE_SELF)
+    print('{:6d} {} ({})'.format(
+        count,
+        format_bytes(after.ru_maxrss),
+        format_bytes(after.ru_maxrss - before.ru_maxrss),
+    ))


### PR DESCRIPTION
This was a layer that was once required for garbage collection due to the
cyclic relationships between containers and streams. Newer Cythons seem to deal
with it better.