### PR TITLE
Make it possible to close input container

### DIFF
--- a/av/container/core.pyx
+++ b/av/container/core.pyx
@@ -150,13 +150,9 @@ cdef class Container(object):
             self.format = build_container_format(self.ptr.iformat, self.ptr.oformat)
 
     def __dealloc__(self):
+        self.close()
 
         with nogil:
-
-            # Let FFmpeg close input if it was fully opened.
-            if self.input_was_opened:
-                lib.avformat_close_input(&self.ptr)
-
             # FFmpeg will not release custom input, so it's up to us to free it.
             # Do not touch our original buffer as it may have been freed and replaced.
             if self.iocontext:

--- a/av/container/input.pyx
+++ b/av/container/input.pyx
@@ -71,6 +71,13 @@ cdef class InputContainer(Container):
     property size:
         def __get__(self): return lib.avio_size(self.ptr.pb)
 
+    def close(self):
+        # Let FFmpeg close input if it was fully opened.
+        if self.input_was_opened:
+            with nogil:
+                lib.avformat_close_input(&self.ptr)
+            self.input_was_opened = False
+
     def demux(self, *args, **kwargs):
         """demux(streams=None, video=None, audio=None, subtitles=None, data=None)
 

--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -20,9 +20,6 @@ cdef class OutputContainer(Container):
         self.streams = StreamContainer()
         self.metadata = {}
 
-    def __dealloc__(self):
-        self.close()
-
     def add_stream(self, codec_name=None, object rate=None, Stream template=None, options=None, **kwargs):
         """add_stream(codec_name, rate=None)
 


### PR DESCRIPTION
This is useful to explicitly close resources such as webcams, without having to wait for the GC to kick in.