### PR TITLE
Stop using nose to run tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ install:
   - conda update conda
   - conda install --yes conda-build jinja2 anaconda-client
   - conda create -q -n test-environment python=%PYTHON_VERSION%
-    pip "setuptools>=0.24" Pillow "Cython>=0.27" "nose>=1.3"
+    pip "setuptools>=0.24" Pillow "Cython>=0.27"
     "numpy>=1.9" "wheel>=0.24" ffmpeg=%FFMPEG_VERSION% msinttypes
   - activate test-environment
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,3 @@ project_urls =
     Documentation = http://docs.mikeboers.com/pyav/
     Feedstock = https://github.com/conda-forge/av-feedstock
     Download = https://pypi.org/project/av
-
-[nosetests]
-verbosity = 2
-logging-clear-handlers = 1

--- a/setup.py
+++ b/setup.py
@@ -512,7 +512,7 @@ setup(
         'cythonize': CythonizeCommand,
     },
 
-    test_suite='nose.collector',
+    test_suite='tests',
 
     entry_points={
         'console_scripts': [

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,6 +3,5 @@ Cython
 editorconfig
 flake8
 isort
-nose
 numpy
 Pillow


### PR DESCRIPTION
Vanilla "unittest" is good enough since Python 2.7 / 3.2.