### PR TITLE
Allow av.open to be used as a context manager

### DIFF
--- a/av/container/core.pyx
+++ b/av/container/core.pyx
@@ -169,6 +169,12 @@ cdef class Container(object):
             # Finish releasing the whole structure.
             lib.avformat_free_context(self.ptr)
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
     def __repr__(self):
         return '<av.%s %r>' % (self.__class__.__name__, self.file or self.name)
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -6,7 +6,7 @@ import unittest
 
 import av
 
-from .common import TestCase
+from .common import TestCase, fate_suite
 
 
 # On Windows, Python 3.0 - 3.5 have issues handling unicode filenames.
@@ -21,6 +21,11 @@ broken_unicode = (
 
 
 class TestContainers(TestCase):
+
+    def test_context_manager(self):
+        with av.open(fate_suite('h264/interlaced_crop.mp4')) as container:
+            self.assertEqual(container.format.long_name, 'QuickTime / MOV')
+            self.assertEqual(len(container.streams), 1)
 
     @unittest.skipIf(broken_unicode, 'Unicode filename handling is broken')
     def test_unicode_filename(self):


### PR DESCRIPTION
This allows us to do:

```python
    with av.open('some_file.mp4') as container:
        ...
```