### PR TITLE
Make audio / video planes property lazy

### DIFF
--- a/av/audio/frame.pyx
+++ b/av/audio/frame.pyx
@@ -81,15 +81,12 @@ cdef class AudioFrame(Frame):
                 align
             ))
 
-            self._init_planes(AudioPlane)
-
     def __dealloc__(self):
         lib.av_freep(&self._buffer)
 
     cdef _init_user_attributes(self):
         self.layout = get_audio_layout(0, self.ptr.channel_layout)
         self.format = get_audio_format(<lib.AVSampleFormat>self.ptr.format)
-        self._init_planes(AudioPlane)
 
     def __repr__(self):
         return '<av.%s %d, pts=%s, %d samples at %dHz, %s, %s at 0x%x>' % (
@@ -130,6 +127,19 @@ cdef class AudioFrame(Frame):
         for i, plane in enumerate(frame.planes):
             plane.update(array[i, :])
         return frame
+
+    @property
+    def planes(self):
+        """
+        A tuple of :class:`~av.audio.plane.AudioPlane`.
+
+        :type: tuple
+        """
+        cdef int plane_count = 0
+        while self.ptr.extended_data[plane_count]:
+            plane_count += 1
+
+        return tuple([AudioPlane(self, i) for i in range(plane_count)])
 
     property samples:
         """

--- a/av/frame.pxd
+++ b/av/frame.pxd
@@ -13,16 +13,6 @@ cdef class Frame(object):
 
     cdef readonly int index
 
-    cdef readonly tuple planes
-    """
-    A tuple of :class:`~av.audio.plane.AudioPlane` or :class:`~av.video.plane.VideoPlane` objects.
-
-    :type: tuple
-    """
-
-    cdef _init_planes(self, cls=?)
-    cdef int _max_plane_count(self)
-
     cdef _copy_internal_attributes(self, Frame source, bint data_layout=?)
 
     cdef _init_user_attributes(self)

--- a/av/frame.pyx
+++ b/av/frame.pyx
@@ -1,8 +1,3 @@
-from libc.limits cimport INT_MAX
-
-from cpython cimport Py_INCREF, PyTuple_New, PyTuple_SET_ITEM
-
-from av.plane cimport Plane
 from av.utils cimport avrational_to_fraction, to_avrational
 
 from fractions import Fraction
@@ -32,29 +27,6 @@ cdef class Frame(object):
             id(self),
             self.pts,
         )
-
-    cdef _init_planes(self, cls=Plane):
-
-        # We need to detect which planes actually exist, but also contrain
-        # ourselves to the maximum plane count (as determined only by VideoFrames
-        # so far), in case the library implementation does not set the last
-        # plane to NULL.
-        cdef int max_plane_count = self._max_plane_count()
-        cdef int plane_count = 0
-        while plane_count < max_plane_count and self.ptr.extended_data[plane_count]:
-            plane_count += 1
-
-        self.planes = PyTuple_New(plane_count)
-        for i in range(plane_count):
-            # We are constructing this tuple manually, but since Cython does
-            # not understand reference stealing we must manually Py_INCREF
-            # so that when Cython Py_DECREFs it doesn't release our object.
-            plane = cls(self, i)
-            Py_INCREF(plane)
-            PyTuple_SET_ITEM(self.planes, i, plane)
-
-    cdef int _max_plane_count(self):
-        return INT_MAX
 
     cdef _copy_internal_attributes(self, Frame source, bint data_layout=True):
         """Mimic another frame."""


### PR DESCRIPTION
This avoids reference loops which make it hard for the garbage collector
to free AudioFrame and VideoFrame instances.