### PR TITLE
Don't call Python methods when deallocating a container

### DIFF
--- a/av/container/core.pyx
+++ b/av/container/core.pyx
@@ -152,8 +152,6 @@ cdef class Container(object):
             self.format = build_container_format(self.ptr.iformat, self.ptr.oformat)
 
     def __dealloc__(self):
-        self.close()
-
         with nogil:
             # FFmpeg will not release custom input, so it's up to us to free it.
             # Do not touch our original buffer as it may have been freed and replaced.


### PR DESCRIPTION
The Cython documentation indicate that calling Python methods inside
__dealloc__ is not safe. While we seem to get away with it on CPython,
PyPy is not so forgiving.