### PR TITLE
Subinterpreters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ addons:
             - yasm
             - zlib1g-dev
     homebrew:
+        # Unfortunately, as of writing, we need to update Homebrew.
+        update: true
         packages:
             - automake
             - libass

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,10 @@ We are operating with `semantic versioning <http://semver.org>`_.
 HEAD
 ----
 
+Minor:
+
+- Users can disable the logging system to avoid lockups in sub-interpreters. (:issue:`545`)
+
 
 v6.2.0
 ------

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -83,6 +83,9 @@ cdef class VideoFrame(Frame):
         self._init(c_format, width, height)
 
     cdef _init(self, lib.AVPixelFormat format, unsigned int width, unsigned int height):
+
+        cdef int res = 0
+
         with nogil:
             self.ptr.width = width
             self.ptr.height = height
@@ -93,16 +96,17 @@ cdef class VideoFrame(Frame):
             # We enforce aligned buffers, otherwise `sws_scale` can perform
             # poorly or even cause out-of-bounds reads and writes.
             if width and height:
-                ret = lib.av_image_alloc(
+                res = lib.av_image_alloc(
                     self.ptr.data,
                     self.ptr.linesize,
                     width,
                     height,
                     format,
                     16)
-                with gil:
-                    err_check(ret)
                 self._buffer = self.ptr.data[0]
+
+        if res:
+            err_check(res)
 
         self._init_user_attributes()
 

--- a/docs/caveats.rst
+++ b/docs/caveats.rst
@@ -1,0 +1,15 @@
+Caveats
+=======
+
+Sub-Interpeters
+---------------
+
+Since we rely upon C callbacks in a few locations, PyAV is not fully compatible with sub-interpreters. Users have experienced lockups in WSGI web applications, for example.
+
+This is due to the ``PyGILState_Ensure`` calls made by Cython in a C callback from FFmpeg. If this is called in a thread that was not started by Python, it is very likely to break. There is no current instrumentation to detect such events.
+
+The two main features that are able to cause lockups are:
+
+1. Python IO (passing a file-like object to ``av.open``). While this is in theory possible, so far it seems like the callbacks are made in the calling thread, and so are safe.
+
+2. Logging. As soon as you en/decode with threads you are highly likely to get log messages issues from threads started by FFmpeg, and you will get lockups. See :ref:`disable_logging`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,7 @@ Overview
 
     about
     installation
+    caveats
 
 
 Cookbook

--- a/include/libavutil/avutil.pxd
+++ b/include/libavutil/avutil.pxd
@@ -327,4 +327,5 @@ cdef extern from "libavutil/log.h" nogil:
 
     # Get the logs.
     ctypedef void(*av_log_callback)(void *, int, const char *, va_list)
+    void av_log_default_callback(void *, int, const char *, va_list)
     void av_log_set_callback (av_log_callback callback)


### PR DESCRIPTION
Users can disable the logging system, which is the harder one the avoid.