### PR TITLE
One line change to make CodecContext.parse use bytes instead of str

### DIFF
--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -167,7 +167,7 @@ cdef class CodecContext(object):
             id(self),
         )
 
-    def parse(self, str input_, allow_stream=False):
+    def parse(self, bytes input_, allow_stream=False):
 
         if not self.parser:
             self.parser = lib.av_parser_init(self.codec.ptr.id)


### PR DESCRIPTION
Avoids encoding and decoding the raw data.