### PR TITLE
Expose swscale flags

### DIFF
--- a/av/video/frame.pxd
+++ b/av/video/frame.pxd
@@ -20,7 +20,7 @@ cdef class VideoFrame(Frame):
     cdef _init(self, lib.AVPixelFormat format, unsigned int width, unsigned int height)
     cdef _init_user_attributes(self)
 
-    cdef _reformat(self, int width, int height, lib.AVPixelFormat format, int src_colorspace, int dst_colorspace)
+    cdef _reformat(self, int width, int height, lib.AVPixelFormat format, int src_colorspace, int dst_colorspace, int flags=?)
 
 
 cdef VideoFrame alloc_video_frame()

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -129,7 +129,7 @@ cdef class VideoFrame(Frame):
             id(self),
         )
 
-    def reformat(self, width=None, height=None, format=None, src_colorspace=None, dst_colorspace=None):
+    def reformat(self, width=None, height=None, format=None, src_colorspace=None, dst_colorspace=None, flags=lib.SWS_BILINEAR):
         """reformat(width=None, height=None, format=None, src_colorspace=None, dst_colorspace=None)
 
         Create a new :class:`VideoFrame` with the given width/height/format/colorspace.
@@ -170,10 +170,11 @@ cdef class VideoFrame(Frame):
             c_dst_colorspace = colorspace_flags[dst_colorspace]
         except KeyError:
             raise ValueError("Invalid dst_colorspace %r" % dst_colorspace)
+        cdef int c_flags = flags
 
-        return self._reformat(width or self.width, height or self.height, video_format.pix_fmt, c_src_colorspace, c_dst_colorspace)
+        return self._reformat(width or self.width, height or self.height, video_format.pix_fmt, c_src_colorspace, c_dst_colorspace, c_flags)
 
-    cdef _reformat(self, int width, int height, lib.AVPixelFormat dst_format, int src_colorspace, int dst_colorspace):
+    cdef _reformat(self, int width, int height, lib.AVPixelFormat dst_format, int src_colorspace, int dst_colorspace, int flags=lib.SWS_BILINEAR):
 
         if self.ptr.format < 0:
             raise ValueError("Frame does not have format set.")
@@ -205,7 +206,7 @@ cdef class VideoFrame(Frame):
                 width,
                 height,
                 dst_format,
-                lib.SWS_BILINEAR,
+                flags,
                 NULL,
                 NULL,
                 NULL

--- a/av/video/reformatter.pyx
+++ b/av/video/reformatter.pyx
@@ -4,3 +4,16 @@ cdef class VideoReformatter(object):
     def __dealloc__(self):
         with nogil:
             lib.sws_freeContext(self.ptr)
+
+SWS_FAST_BILINEAR = lib.SWS_FAST_BILINEAR
+SWS_BILINEAR = lib.SWS_BILINEAR
+SWS_BICUBIC = lib.SWS_BICUBIC
+SWS_X = lib.SWS_X
+SWS_POINT = lib.SWS_POINT
+SWS_AREA = lib.SWS_AREA
+SWS_BICUBLIN = lib.SWS_BICUBLIN
+SWS_GAUSS = lib.SWS_GAUSS
+SWS_SINC = lib.SWS_SINC
+SWS_LANCZOS = lib.SWS_LANCZOS
+SWS_SPLINE = lib.SWS_SPLINE
+

--- a/include/libswscale/swscale.pxd
+++ b/include/libswscale/swscale.pxd
@@ -14,8 +14,17 @@ cdef extern from "libswscale/swscale.h" nogil:
         pass
 
     # Flags.
+    cdef int SWS_FAST_BILINEAR
     cdef int SWS_BILINEAR
     cdef int SWS_BICUBIC
+    cdef int SWS_X
+    cdef int SWS_POINT
+    cdef int SWS_AREA
+    cdef int SWS_BICUBLIN
+    cdef int SWS_GAUSS
+    cdef int SWS_SINC
+    cdef int SWS_LANCZOS
+    cdef int SWS_SPLINE
 
     cdef int SWS_CS_ITU709
     cdef int SWS_CS_FCC


### PR DESCRIPTION
Early implement for #577 
I've been using this indoor for months. My main hesitation to upstream this was its change to API.
A new argument with default value was added to `VideoFrame._reformat`. It seems that argument with default value was never use in `cdef` in this project, but this is probably the only way not to break existing code.
Please consider this as a proposal. I would like to update this PR to meet up with an updated API design.