### PR TITLE
updated examples, added container.close()

### DIFF
--- a/examples/basics/remux.py
+++ b/examples/basics/remux.py
@@ -1,4 +1,3 @@
-import av
 import av.datasets
 
 
@@ -23,4 +22,5 @@ for packet in input_.demux(in_stream):
 
     output.mux(packet)
 
+input_.close()
 output.close()

--- a/examples/basics/save_keyframes.py
+++ b/examples/basics/save_keyframes.py
@@ -1,20 +1,18 @@
-import av
 import av.datasets
 
 
-container = av.open(av.datasets.curated('pexels/time-lapse-video-of-night-sky-857195.mp4'))
+content = av.datasets.curated('pexels/time-lapse-video-of-night-sky-857195.mp4')
+with av.open(content) as container:
+    # Signal that we only want to look at keyframes.
+    stream = container.streams.video[0]
+    stream.codec_context.skip_frame = 'NONKEY'
 
+    for frame in container.decode(stream):
 
-# Signal that we only want to look at keyframes.
-stream = container.streams.video[0]
-stream.codec_context.skip_frame = 'NONKEY'
+        print(frame)
 
-for frame in container.decode(stream):
-
-    print(frame)
-
-    # We use `frame.pts` as `frame.index` won't make must sense with the `skip_frame`.
-    frame.to_image().save(
-        'night-sky.{:04d}.jpg'.format(frame.pts),
-        quality=80,
-    )
+        # We use `frame.pts` as `frame.index` won't make must sense with the `skip_frame`.
+        frame.to_image().save(
+            'night-sky.{:04d}.jpg'.format(frame.pts),
+            quality=80,
+        )

--- a/examples/basics/thread_type.py
+++ b/examples/basics/thread_type.py
@@ -1,6 +1,5 @@
 import time
 
-import av
 import av.datasets
 
 
@@ -15,6 +14,7 @@ for packet in container.demux():
         print(frame)
 
 default_time = time.time() - start_time
+container.close()
 
 
 print("Decoding with auto threading...")
@@ -31,6 +31,7 @@ for packet in container.demux():
         print(frame)
 
 auto_time = time.time() - start_time
+container.close()
 
 
 print("Decoded with default threading in {:.2f}s.".format(default_time))

--- a/examples/numpy/barcode.py
+++ b/examples/numpy/barcode.py
@@ -1,7 +1,6 @@
 from PIL import Image
 import numpy as np
 
-import av
 import av.datasets
 
 
@@ -24,6 +23,9 @@ for frame in container.decode(video=0):
     column = column.reshape(-1, 1, 3)
 
     columns.append(column)
+
+# Close the file, free memory
+container.close()
 
 full_array = np.hstack(columns)
 full_img = Image.fromarray(full_array, 'RGB')


### PR DESCRIPTION
I took code from example as a base and got a memory leak. Reason: there is no `close` method for the container.

I verified on small video: 2sec, 360:

without close:
<img width="700" alt="without_close" src="https://user-images.githubusercontent.com/628807/70720026-be1a8700-1cfb-11ea-854f-60d3852688e1.png">


with close:
<img width="700" alt="with_close" src="https://user-images.githubusercontent.com/628807/70720043-c2df3b00-1cfb-11ea-8fdc-8f14aed74e5b.png">


Simplified code:
```python
import av
import av.datasets
import psutil

current_process = psutil.Process()

get_mem_uss = lambda: current_process.memory_full_info().uss

PATH = '...'


def read_frames(path):
    container = av.open(path)
    return [frame.to_ndarray(format='yuv420p') for frame in container.decode(video=0)]


started_with = get_mem_uss()
for i in range(15000):
    read_frames(PATH)
    if i % 50:
        print(f'Used memory {(get_mem_uss() - started_with) / 1024 / 1024}')

```

