### PR TITLE
added yuvj420p format for to_ndarray

### DIFF
--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -236,7 +236,7 @@ cdef class VideoFrame(Frame):
 
         import numpy as np
 
-        if frame.format.name == 'yuv420p':
+        if frame.format.name in ('yuv420p', 'yuvj420p'):
             assert frame.width % 2 == 0
             assert frame.height % 2 == 0
             return np.hstack((
@@ -277,7 +277,7 @@ cdef class VideoFrame(Frame):
         """
         Construct a frame from a numpy array.
         """
-        if format == 'yuv420p':
+        if format in ('yuv420p', 'yuvj420p'):
             assert array.dtype == 'uint8'
             assert array.ndim == 2
             assert array.shape[0] % 3 == 0

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -236,6 +236,14 @@ class TestVideoFrameNdarray(TestCase):
         self.assertEqual(frame.format.name, 'yuv420p')
         self.assertTrue((frame.to_ndarray() == array).all())
 
+    def test_ndarray_yuvj420p(self):
+        array = numpy.random.randint(0, 256, size=(720, 640), dtype=numpy.uint8)
+        frame = VideoFrame.from_ndarray(array, format='yuvj420p')
+        self.assertEqual(frame.width, 640)
+        self.assertEqual(frame.height, 480)
+        self.assertEqual(frame.format.name, 'yuvj420p')
+        self.assertTrue((frame.to_ndarray() == array).all())
+
     def test_ndarray_yuyv422(self):
         array = numpy.random.randint(0, 256, size=(480, 640, 2), dtype=numpy.uint8)
         frame = VideoFrame.from_ndarray(array, format='yuyv422')


### PR DESCRIPTION
`yuvj420p` has the same shape as `yuv420p`. The difference in color ranges: 

- `yuv420p` according to rec 709 (https://en.wikipedia.org/wiki/Rec._709#Digital_representation) has a nominal range of [16..235] for Y channel and CB and CR channels have a nominal range of [16..240]. rec 601 has limited ranges also. It's main recommendations for `yuv420p` (https://en.wikipedia.org/wiki/YUV) 


- `yuvj420p` like I420, but with a full range ("digital", 0-255) (https://wiki.videolan.org/YUV#J420)


