### PR TITLE
Support for more pixel formats

### DIFF
--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -132,7 +132,11 @@ cdef class VideoFrame(Frame):
         # ourselves to the maximum plane count (as determined only by VideoFrames
         # so far), in case the library implementation does not set the last
         # plane to NULL.
-        cdef int max_plane_count = self.format.ptr.nb_components
+        cdef int max_plane_count = 0
+        for i in range(self.format.ptr.nb_components):
+            count = self.format.ptr.comp[i].plane + 1
+            if max_plane_count < count:
+                max_plane_count = count
         cdef int plane_count = 0
         while plane_count < max_plane_count and self.ptr.extended_data[plane_count]:
             plane_count += 1
@@ -257,7 +261,7 @@ cdef class VideoFrame(Frame):
             return useful_array(frame.planes[0], 3).reshape(frame.height, frame.width, -1)
         elif frame.format.name in ('argb', 'rgba', 'abgr', 'bgra'):
             return useful_array(frame.planes[0], 4).reshape(frame.height, frame.width, -1)
-        elif frame.format.name in ('gray', 'gray8'):
+        elif frame.format.name in ('gray', 'gray8', 'rgb8', 'bgr8'):
             return useful_array(frame.planes[0]).reshape(frame.height, frame.width)
         else:
             raise ValueError('Conversion to numpy array with format `%s` is not yet supported' % frame.format.name)
@@ -309,7 +313,7 @@ cdef class VideoFrame(Frame):
             assert array.dtype == 'uint8'
             assert array.ndim == 3
             assert array.shape[2] == 4
-        elif format in ('gray', 'gray8'):
+        elif format in ('gray', 'gray8', 'rgb8', 'bgr8'):
             assert array.dtype == 'uint8'
             assert array.ndim == 2
         else:

--- a/av/video/frame.pyx
+++ b/av/video/frame.pyx
@@ -244,7 +244,7 @@ cdef class VideoFrame(Frame):
         .. note:: Numpy must be installed.
 
         .. note:: For ``pal8``, an ``(image, palette)`` tuple will be returned,
-        with the palette being in ARGB (PyAV will swap bytes according to endianness).
+        with the palette being in ARGB (PyAV will swap bytes if needed).
 
         """
         cdef VideoFrame frame = self.reformat(**kwargs)
@@ -292,14 +292,16 @@ cdef class VideoFrame(Frame):
         return frame
 
     @staticmethod
-    def from_ndarray(array, format='rgb24', palette=None):
+    def from_ndarray(array, format='rgb24'):
         """
         Construct a frame from a numpy array.
 
-        .. note:: ``palette`` must be given only for ``pal8``, and in ARGB format
-        (PyAV will swap bytes according to the endianness).
+        .. note:: for ``pal8``, an ``(image, palette)`` pair must be passed.
+        `palette` must have shape (256, 4) and is given in ARGB format
+        (PyAV will swap bytes if needed).
         """
         if format == 'pal8':
+            array, palette = array
             assert array.dtype == 'uint8'
             assert array.ndim == 2
             assert palette.dtype == 'uint8'
@@ -308,7 +310,6 @@ cdef class VideoFrame(Frame):
             copy_array_to_plane(array, frame.planes[0], 1)
             frame.planes[1].update(palette.view('>i4').astype('i4').tobytes())
             return frame
-        assert palette is None
 
         if format in ('yuv420p', 'yuvj420p'):
             assert array.dtype == 'uint8'

--- a/av/video/plane.pxd
+++ b/av/video/plane.pxd
@@ -4,7 +4,5 @@ from av.video.format cimport VideoFormatComponent
 
 cdef class VideoPlane(Plane):
 
-    cdef VideoFormatComponent component
-
     cdef readonly size_t buffer_size
     cdef readonly unsigned int width, height

--- a/av/video/plane.pxd
+++ b/av/video/plane.pxd
@@ -7,3 +7,4 @@ cdef class VideoPlane(Plane):
     cdef VideoFormatComponent component
 
     cdef readonly size_t buffer_size
+    cdef readonly unsigned int width, height

--- a/av/video/plane.pyx
+++ b/av/video/plane.pyx
@@ -5,6 +5,7 @@ cdef class VideoPlane(Plane):
 
     def __cinit__(self, VideoFrame frame, int index):
 
+        # The palette plane has no associated component or linesize; set fields manually
         if frame.format.name == 'pal8' and index == 1:
             self.width = 256
             self.height = 1

--- a/tests/test_videoframe.py
+++ b/tests/test_videoframe.py
@@ -260,6 +260,34 @@ class TestVideoFrameNdarray(TestCase):
         self.assertEqual(frame.format.name, 'yuyv422')
         self.assertTrue((frame.to_ndarray() == array).all())
 
+    def test_ndarray_rgb8(self):
+        array = numpy.random.randint(0, 256, size=(480, 640), dtype=numpy.uint8)
+        frame = VideoFrame.from_ndarray(array, format='rgb8')
+        self.assertEqual(frame.width, 640)
+        self.assertEqual(frame.height, 480)
+        self.assertEqual(frame.format.name, 'rgb8')
+        self.assertTrue((frame.to_ndarray() == array).all())
+
+    def test_ndarray_bgr8(self):
+        array = numpy.random.randint(0, 256, size=(480, 640), dtype=numpy.uint8)
+        frame = VideoFrame.from_ndarray(array, format='bgr8')
+        self.assertEqual(frame.width, 640)
+        self.assertEqual(frame.height, 480)
+        self.assertEqual(frame.format.name, 'bgr8')
+        self.assertTrue((frame.to_ndarray() == array).all())
+
+    def test_ndarray_pal8(self):
+        array = numpy.random.randint(0, 256, size=(480, 640), dtype=numpy.uint8)
+        palette = numpy.random.randint(0, 256, size=(256, 4), dtype=numpy.uint8)
+        frame = VideoFrame.from_ndarray((array, palette), format='pal8')
+        self.assertEqual(frame.width, 640)
+        self.assertEqual(frame.height, 480)
+        self.assertEqual(frame.format.name, 'pal8')
+        returned = frame.to_ndarray()
+        self.assertTrue((type(returned) is tuple) and len(returned) == 2)
+        self.assertTrue((returned[0] == array).all())
+        self.assertTrue((returned[1] == palette).all())
+
 
 class TestVideoFrameTiming(TestCase):
 


### PR DESCRIPTION
- Fixes plane count calculation at `VideoFrame.planes` (in cases when many components are stored in the same plane).
- Corrects the `VideoPlane` constructor so that the palette plane in `pal8` is accessible.
- Implements ndarray conversion with `rgb8` / `bgr8`.
- Implements ndarray conversion with `pal8` (by accepting a `palette` argument / returning a tuple).