### PR TITLE
Use os.fsencode for both input and output file names (fixes: #600)

### DIFF
--- a/av/container/core.pyx
+++ b/av/container/core.pyx
@@ -2,7 +2,7 @@ from libc.stdint cimport int64_t
 from libc.stdlib cimport malloc, free
 from cython.operator cimport dereference
 
-import sys
+import os
 import time
 
 cimport libav as lib
@@ -18,15 +18,6 @@ from av.utils cimport dict_to_avdict
 
 from av.dictionary import Dictionary
 from av.logging import Capture as LogCapture
-
-try:
-    from os import fsencode
-except ImportError:
-    _fsencoding = sys.getfilesystemencoding()
-
-    def fsencode(s):
-        return s.encode(_fsencoding)
-
 
 ctypedef int64_t (*seek_func_t)(void *opaque, int64_t offset, int whence) nogil
 
@@ -143,7 +134,7 @@ cdef class Container(object):
         self.input_was_opened = False
         cdef int res
 
-        cdef bytes name_obj = fsencode(self.name) if isinstance(self.name, unicode) else self.name
+        cdef bytes name_obj = os.fsencode(self.name)
         cdef char *name = name_obj
         cdef seek_func_t seek_func = NULL
 

--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -1,4 +1,5 @@
 from fractions import Fraction
+import os
 import logging
 
 from av.codec.codec cimport Codec
@@ -162,7 +163,8 @@ cdef class OutputContainer(Container):
             stream._finalize_for_output()
 
         # Open the output file, if needed.
-        cdef char *name = "" if self.file is not None else self.name
+        cdef bytes name_obj = os.fsencode(self.name if self.file is None else "")
+        cdef char *name = name_obj
         if self.ptr.pb == NULL and not self.ptr.oformat.flags & lib.AVFMT_NOFILE:
             err_check(lib.avio_open(&self.ptr.pb, name, lib.AVIO_FLAG_WRITE))
 


### PR DESCRIPTION
It's safe to call os.fsencode() regardless of whether the filename was
passed as `bytes` or `str`. Remove shim for `os.fsencode()`, it has been
available since Python 3.2.