### PR TITLE
Remove some references to Python 2

### DIFF
--- a/AUTHORS.py
+++ b/AUTHORS.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import math
 import subprocess
 

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -25,7 +25,7 @@ We will also sometimes duplicate APIs in order to provide both a low-level and h
 Version Compatibility
 ---------------------
 
-We currently support FFmpeg 4.0 through 4.2, on Python 2.7 and 3.3 through 3.7, on Linux, macOS, and Windows. We `continually test <https://github.com/mikeboers/PyAV/actions>`_  these configurations.
+We currently support FFmpeg 4.0 through 4.2, on Python 3.5 through 3.8, on Linux, macOS, and Windows. We `continually test <https://github.com/mikeboers/PyAV/actions>`_  these configurations.
 
 Differences are handled at compile time, in C, by checking against ``LIBAV*_VERSION_INT`` macros. We have not been able to perform this sort of checking in Cython as we have not been able to have it fully remove the code-paths, and so there are missing functions in newer FFmpeg's, and deprecated ones that emit compiler warnings in older FFmpeg's.
 

--- a/av/__main__.py
+++ b/av/__main__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import argparse
 
 

--- a/av/audio/layout.pyx
+++ b/av/audio/layout.pyx
@@ -76,7 +76,7 @@ cdef class AudioLayout(object):
             if layout < 0 or layout > 8:
                 raise ValueError('no layout with %d channels' % layout)
             c_layout = default_layouts[layout]
-        elif isinstance(layout, basestring):
+        elif isinstance(layout, str):
             c_layout = lib.av_get_channel_layout(layout)
         elif isinstance(layout, AudioLayout):
             c_layout = layout.layout

--- a/av/codec/context.pyx
+++ b/av/codec/context.pyx
@@ -12,7 +12,7 @@ from av.dictionary import Dictionary
 from av.enum cimport define_enum
 from av.error cimport err_check
 from av.packet cimport Packet
-from av.utils cimport avdict_to_dict, avrational_to_fraction, to_avrational
+from av.utils cimport avrational_to_fraction, to_avrational
 
 
 cdef object _cinit_sentinel = object()

--- a/av/container/core.pyx
+++ b/av/container/core.pyx
@@ -14,7 +14,6 @@ from av.container.pyio cimport pyio_read, pyio_write, pyio_seek
 from av.enum cimport define_enum
 from av.error cimport err_check, stash_exception
 from av.format cimport build_container_format
-from av.utils cimport dict_to_avdict
 
 from av.dictionary import Dictionary
 from av.logging import Capture as LogCapture
@@ -110,11 +109,11 @@ cdef class Container(object):
         if not self.writeable and not isinstance(self, InputContainer):
             raise RuntimeError('Container cannot be directly extended.')
 
-        if isinstance(file_, basestring):
+        if isinstance(file_, str):
             self.name = file_
         else:
             self.name = getattr(file_, 'name', '<none>')
-            if not isinstance(self.name, basestring):
+            if not isinstance(self.name, str):
                 raise TypeError("File's name attribute must be string-like.")
             self.file = file_
 
@@ -305,7 +304,7 @@ cdef class Container(object):
 
 def open(file, mode=None, format=None, options=None,
          container_options=None, stream_options=None,
-         metadata_encoding=None, metadata_errors='strict',
+         metadata_encoding='utf-8', metadata_errors='strict',
          buffer_size=32768, timeout=None):
     """open(file, mode='r', **kwargs)
 
@@ -318,10 +317,9 @@ def open(file, mode=None, format=None, options=None,
     :param dict container_options: Options to pass to the container.
     :param list stream_options: Options to pass to each stream.
     :param str metadata_encoding: Encoding to use when reading or writing file metadata.
-        Defaults to utf-8, except no decoding is performed by default when
-        reading on Python 2 (returning ``str`` instead of ``unicode``).
+        Defaults to ``"utf-8"``.
     :param str metadata_errors: Specifies how to handle encoding errors; behaves like
-        ``str.encode`` parameter. Defaults to strict.
+        ``str.encode`` parameter. Defaults to ``"strict"``.
     :param int buffer_size: Size of buffer for Python input/output operations in bytes.
         Honored only when ``file`` is a file-like object. Defaults to 32768 (32k).
     :param timeout: How many seconds to wait for data before giving up, as a float, or a

--- a/av/container/output.pyx
+++ b/av/container/output.pyx
@@ -169,8 +169,11 @@ cdef class OutputContainer(Container):
             err_check(lib.avio_open(&self.ptr.pb, name, lib.AVIO_FLAG_WRITE))
 
         # Copy the metadata dict.
-        dict_to_avdict(&self.ptr.metadata, self.metadata, clear=True,
-                       encoding=self.metadata_encoding, errors=self.metadata_errors)
+        dict_to_avdict(
+            &self.ptr.metadata, self.metadata,
+            encoding=self.metadata_encoding,
+            errors=self.metadata_errors
+        )
 
         cdef _Dictionary all_options = Dictionary(self.options, self.container_options)
         cdef _Dictionary options = all_options.copy()

--- a/av/enum.pyx
+++ b/av/enum.pyx
@@ -60,7 +60,7 @@ class EnumType(type):
 
     def __getitem__(self, key):
 
-        if isinstance(key, basestring):
+        if isinstance(key, str):
             return self._by_name[key]
 
         if isinstance(key, int):
@@ -217,7 +217,7 @@ cdef class EnumItem(object):
 
     def __eq__(self, other):
 
-        if isinstance(other, basestring):
+        if isinstance(other, str):
 
             if self.name == other:  # The quick method.
                 return True

--- a/av/error.pyx
+++ b/av/error.pyx
@@ -41,12 +41,11 @@ cpdef tag_to_code(bytes tag):
     """
     if len(tag) != 4:
         raise ValueError("Error tags are 4 bytes.")
-    atag = bytearray(tag)  # Python 2. Ugh.
     return (
-        (atag[0]) +
-        (atag[1] << 8) +
-        (atag[2] << 16) +
-        (atag[3] << 24)
+        (tag[0]) +
+        (tag[1] << 8) +
+        (tag[2] << 16) +
+        (tag[3] << 24)
     )
 
 

--- a/av/filter/filter.pyx
+++ b/av/filter/filter.pyx
@@ -26,7 +26,7 @@ cdef class Filter(object):
     def __cinit__(self, name):
         if name is _cinit_sentinel:
             return
-        if not isinstance(name, basestring):
+        if not isinstance(name, str):
             raise TypeError('takes a filter name as a string')
         self.ptr = lib.avfilter_get_by_name(name)
         if not self.ptr:

--- a/av/filter/graph.pyx
+++ b/av/filter/graph.pyx
@@ -76,7 +76,7 @@ cdef class Graph(object):
     def add(self, filter, args=None, **kwargs):
 
         cdef Filter cy_filter
-        if isinstance(filter, basestring):
+        if isinstance(filter, str):
             cy_filter = Filter(filter)
         elif isinstance(filter, Filter):
             cy_filter = filter

--- a/av/stream.pyx
+++ b/av/stream.pyx
@@ -129,7 +129,6 @@ cdef class Stream(object):
 
         dict_to_avdict(
             &self._stream.metadata, self.metadata,
-            clear=True,
             encoding=self.container.metadata_encoding,
             errors=self.container.metadata_errors,
         )

--- a/av/utils.pxd
+++ b/av/utils.pxd
@@ -3,8 +3,8 @@ from libc.stdint cimport int64_t, uint8_t, uint64_t
 cimport libav as lib
 
 
-cdef dict avdict_to_dict(lib.AVDictionary *input, str encoding=*, str errors=*)
-cdef dict_to_avdict(lib.AVDictionary **dst, dict src, bint clear=*, str encoding=*, str errors=*)
+cdef dict avdict_to_dict(lib.AVDictionary *input, str encoding, str errors)
+cdef dict_to_avdict(lib.AVDictionary **dst, dict src, str encoding, str errors)
 
 
 cdef object avrational_to_fraction(const lib.AVRational *input)

--- a/av/utils.pyx
+++ b/av/utils.pyx
@@ -14,14 +14,9 @@ cdef _decode(char *s, encoding, errors):
     return (<bytes>s).decode(encoding, errors)
 
 cdef bytes _encode(s, encoding, errors):
-    if isinstance(s, unicode):
-        return s.encode(encoding, errors)
-    return s
+    return s.encode(encoding, errors)
 
-cdef dict avdict_to_dict(lib.AVDictionary *input, str encoding=None, str errors='strict'):
-    if encoding is None:
-        encoding = 'utf8'
-
+cdef dict avdict_to_dict(lib.AVDictionary *input, str encoding, str errors):
     cdef lib.AVDictionaryEntry *element = NULL
     cdef dict output = {}
     while True:
@@ -32,11 +27,8 @@ cdef dict avdict_to_dict(lib.AVDictionary *input, str encoding=None, str errors=
     return output
 
 
-cdef dict_to_avdict(lib.AVDictionary **dst, dict src, bint clear=True, str encoding=None, str errors='strict'):
-    if clear:
-        lib.av_dict_free(dst)
-    if encoding is None:
-        encoding = 'utf8'
+cdef dict_to_avdict(lib.AVDictionary **dst, dict src, str encoding, str errors):
+    lib.av_dict_free(dst)
     for key, value in src.items():
         err_check(lib.av_dict_set(dst, _encode(key, encoding, errors),
                                   _encode(value, encoding, errors), 0))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # -*- coding: utf-8 -*-
 #
 # PyAV documentation build configuration file, created by

--- a/docs/development/includes.py
+++ b/docs/development/includes.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import os
 import re

--- a/docs/generate-tagfile
+++ b/docs/generate-tagfile
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import os
 import subprocess
 import argparse

--- a/scratchpad/glproxy.py
+++ b/scratchpad/glproxy.py
@@ -45,7 +45,7 @@ class GLProxy(ModuleProxy):
     def attrib(self, *args):
         mask = 0
         for arg in args:
-            if isinstance(arg, basestring):
+            if isinstance(arg, str):
                 arg = getattr(self.module, 'GL_%s_BIT' % arg.upper())
             mask |= arg
         self.module.glPushAttrib(mask)
@@ -65,7 +65,7 @@ class GLProxy(ModuleProxy):
     def _enable(self, enable, args, kwargs):
         todo = []
         for arg in args:
-            if isinstance(arg, basestring):
+            if isinstance(arg, str):
                 arg = getattr(self.module, 'GL_%s' % arg.upper())
             todo.append((arg, enable))
         for key, value in kwargs.iteritems():
@@ -79,7 +79,7 @@ class GLProxy(ModuleProxy):
                 self.module.glDisable(flag)
 
     def begin(self, arg):
-        if isinstance(arg, basestring):
+        if isinstance(arg, str):
             arg = getattr(self.module, 'GL_%s' % arg.upper())
         self.module.glBegin(arg)
         return self._apply_on_exit(self.module.glEnd)

--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -53,7 +53,6 @@ if [[ "$GITHUB_ACTION" || "$TRAVIS" ]]; then
 else
 
     export PYAV_VENV_NAME="$(uname -s).$(uname -r).$("$PYAV_PYTHON" -c '
-from __future__ import print_function
 import sys
 import platform
 print("{}{}.{}".format(platform.python_implementation().lower(), *sys.version_info[:2]))

--- a/scripts/autolint
+++ b/scripts/autolint
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import argparse
 import fnmatch
 import os

--- a/scripts/clean-branches
+++ b/scripts/clean-branches
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-
 import subprocess
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from distutils.ccompiler import new_compiler as _new_compiler
 from distutils.command.clean import clean, log
 from distutils.core import Command

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,5 +1,3 @@
-# coding: utf8
-
 import sys
 import unittest
 

--- a/tests/test_doctests.py
+++ b/tests/test_doctests.py
@@ -6,12 +6,6 @@ import re
 import av
 
 
-try:
-    basestring
-except NameError:
-    basestring = str
-
-
 def fix_doctests(suite):
 
     for case in suite._tests:
@@ -36,7 +30,7 @@ def fix_doctests(suite):
 
 def register_doctests(mod):
 
-    if isinstance(mod, basestring):
+    if isinstance(mod, str):
         mod = __import__(mod, fromlist=[''])
 
     try:

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,19 +1,11 @@
+from http.server import BaseHTTPRequestHandler
+from socketserver import TCPServer
 import threading
 import time
 
 import av
 
 from .common import TestCase, fate_suite
-
-
-try:
-    # Python 3
-    from http.server import BaseHTTPRequestHandler
-    from socketserver import TCPServer
-except ImportError:
-    # Python 2
-    from BaseHTTPServer import BaseHTTPRequestHandler
-    from SocketServer import TCPServer
 
 
 PORT = 8002


### PR DESCRIPTION
Also simplify the `dict_to_avdict` signature as we:

- always pass `clear=True`
- always explicitly pass the `encoding` and `errors` arguments